### PR TITLE
add-get-download-url

### DIFF
--- a/migrations/20250723093841.sql
+++ b/migrations/20250723093841.sql
@@ -1,0 +1,2 @@
+DELETE FROM publisher_permission_group
+WHERE name = 'GAME CONTENT MANAGEMENT';

--- a/migrations/20250723160127_add-file-size-to-game-version.sql
+++ b/migrations/20250723160127_add-file-size-to-game-version.sql
@@ -1,0 +1,2 @@
+-- Modify "game_version" table
+ALTER TABLE "public"."game_version" ADD COLUMN "file_size" bigint NULL;

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:fGKRrqQIP4imb2r9/jhvkGnCqWwUCj7qwnG2CXZhqW8=
+h1:6FCih9pTznstqinTuallj32HHY4gHNFGf4rwrW1la/Q=
 20250706170756_migrate-datetime-to-bigint.sql h1:5JrcN/MgdPa3aItd1d1933e6qfnTW8l6qRWiXP76nQQ=
 20250706170919_add-game-default-created-at.sql h1:8EqGnGq3gsxGa0YGT0c1Q9yxTXsUglQe9fSKYUP96Bo=
 20250706170931.sql h1:VdBUOWMkg+Ua82QGrSeIZ2luY6+z7Wr0LHjCTE1A5So=
@@ -6,3 +6,5 @@ h1:fGKRrqQIP4imb2r9/jhvkGnCqWwUCj7qwnG2CXZhqW8=
 20250712080150_add-wish-list.sql h1:SNdeOmc1ewqEdfMsmqM9osOrUvl9LVbwF5jHxHvR0Oo=
 20250712084301_remove-unique-account.sql h1:E4RKVKXCbY6m2fSHvW6OE0iOlOe2o7YCA0gjTfa15gE=
 20250720090202.sql h1:S09Q1sGMsdS8qIzYJzaPD3d+oj5MWrrSHja0WYLzzX8=
+20250723093841.sql h1:lO2YsSr/5e0FngyC/KsjV72bazJoOr+yS+bi0x8+Cdc=
+20250723160127_add-file-size-to-game-version.sql h1:0UA4S6FDbZW1s4F19k2tGi9Js9/R7SOHPg1sRuQeiGI=

--- a/schema.pg.hcl
+++ b/schema.pg.hcl
@@ -150,6 +150,10 @@ table "game_version" {
     null = false
     type = integer
   }
+  column "file_size" {
+    null = true
+    type = bigint
+  }
   column "release_date" {
     null = false
     type = bigint

--- a/src/main/java/com/bravos/steak/administration/service/impl/GameReviewServiceImpl.java
+++ b/src/main/java/com/bravos/steak/administration/service/impl/GameReviewServiceImpl.java
@@ -50,10 +50,15 @@ public class GameReviewServiceImpl implements GameReviewService {
     private final GameDetailsRepository gameDetailsRepository;
     private final GameSubmissionService gameSubmissionService;
 
-    public GameReviewServiceImpl(GameSubmissionRepository gameSubmissionRepository, ReviewReplyRepository reviewReplyRepository,
-                                 SessionService sessionService, PublisherRepository publisherRepository, GameRepository gameRepository,
-                                 SnowflakeGenerator snowflakeGenerator, GameVersionRepository gameVersionRepository,
-                                 GameDetailsRepository gameDetailsRepository, GameSubmissionService gameSubmissionService) {
+    public GameReviewServiceImpl(GameSubmissionRepository gameSubmissionRepository,
+                                 ReviewReplyRepository reviewReplyRepository,
+                                 SessionService sessionService,
+                                 PublisherRepository publisherRepository,
+                                 GameRepository gameRepository,
+                                 SnowflakeGenerator snowflakeGenerator,
+                                 GameVersionRepository gameVersionRepository,
+                                 GameDetailsRepository gameDetailsRepository,
+                                 GameSubmissionService gameSubmissionService) {
         this.gameSubmissionRepository = gameSubmissionRepository;
         this.reviewReplyRepository = reviewReplyRepository;
         this.sessionService = sessionService;
@@ -83,7 +88,8 @@ public class GameReviewServiceImpl implements GameReviewService {
     @Transactional
     public void approveGameSubmission(Long submissionId) {
         GameSubmission submission = gameSubmissionRepository.findById(submissionId)
-                .orElseThrow(() -> new ResourceNotFoundException("Game submission not found with ID: " + submissionId));
+                .orElseThrow(() ->
+                        new ResourceNotFoundException("Game submission not found with ID: " + submissionId));
 
         if(submission.getStatus() != GameSubmissionStatus.PENDING_REVIEW) {
             throw new BadRequestException("Game submission is not in pending review status");
@@ -122,6 +128,8 @@ public class GameReviewServiceImpl implements GameReviewService {
                 .name(submission.getBuildInfo().getVersionName())
                 .execPath(submission.getBuildInfo().getExecPath())
                 .downloadUrl(submission.getBuildInfo().getDownloadUrl())
+                .fileSize(submission.getBuildInfo().getFileSize())
+                .checksum(submission.getBuildInfo().getChecksum())
                 .createdAt(DateTimeHelper.currentTimeMillis())
                 .releaseDate(game.getReleaseDate())
                 .status(VersionStatus.STABLE)

--- a/src/main/java/com/bravos/steak/common/service/redis/RedisService.java
+++ b/src/main/java/com/bravos/steak/common/service/redis/RedisService.java
@@ -1,6 +1,7 @@
 package com.bravos.steak.common.service.redis;
 
 import com.bravos.steak.common.model.RedisCacheEntry;
+import com.fasterxml.jackson.databind.type.CollectionLikeType;
 
 import java.util.Collection;
 import java.util.List;
@@ -19,6 +20,8 @@ public interface RedisService {
     boolean hasKey(String key);
 
     <T> T get(String key, Class<T> clazz);
+
+    <T> Collection<T> get(String key, CollectionLikeType type, Class<T> clazz);
 
     <T> List<T> multiGet(Collection<String> key, Class<T> clazz);
 

--- a/src/main/java/com/bravos/steak/common/service/redis/impl/RedisServiceImpl.java
+++ b/src/main/java/com/bravos/steak/common/service/redis/impl/RedisServiceImpl.java
@@ -4,6 +4,7 @@ import com.bravos.steak.common.model.RedisCacheEntry;
 import com.bravos.steak.common.service.redis.RedisService;
 import com.bravos.steak.common.service.webhook.DiscordWebhookService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.CollectionLikeType;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.support.NullValue;
@@ -86,6 +87,18 @@ public class RedisServiceImpl implements RedisService {
         } catch (Exception e) {
             log.error("Error when getting data: {}", e.getMessage(), e);
             throw new RuntimeException("Error when getting data");
+        }
+    }
+
+    @Override
+    public <T> Collection<T> get(String key, CollectionLikeType type, Class<T> clazz) {
+        Object value = redisTemplate.opsForValue().get(key);
+        if(value == null) return List.of();
+        try {
+            return objectMapper.convertValue(value, type);
+        } catch (IllegalArgumentException e) {
+            log.error("Error when converting data: {}", e.getMessage(), e);
+            throw new RuntimeException("Error when converting data: " + e.getMessage(), e);
         }
     }
 

--- a/src/main/java/com/bravos/steak/dev/controller/PublisherManagerController.java
+++ b/src/main/java/com/bravos/steak/dev/controller/PublisherManagerController.java
@@ -30,6 +30,22 @@ public class PublisherManagerController {
         return ResponseEntity.ok(publisherManagerService.getPublisherAccounts(page, size, status));
     }
 
+    @GetMapping("/accounts/search")
+    @HasAuthority({PublisherAuthority.READ_MEMBERS})
+    public ResponseEntity<?> searchPublisherAccounts(
+            @RequestParam String keyword,
+            @RequestParam(defaultValue = "all") String status,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "15") int size) {
+        return ResponseEntity.ok(publisherManagerService.searchPublisherAccounts(keyword, status, page, size));
+    }
+
+    @GetMapping("/permissions")
+    @HasAuthority({PublisherAuthority.READ_MEMBERS})
+    public ResponseEntity<?> getPublisherPermissions() {
+        return ResponseEntity.ok(publisherManagerService.getPublisherPermissions());
+    }
+
     @GetMapping("/custom-roles")
     @HasAuthority({PublisherAuthority.WRITE_MEMBERS})
     public ResponseEntity<?> getCustomRoleList() {
@@ -49,7 +65,7 @@ public class PublisherManagerController {
     }
 
     @GetMapping("/role")
-    @HasAuthority({PublisherAuthority.WRITE_MEMBERS})
+    @HasAuthority({PublisherAuthority.READ_MEMBERS})
     public ResponseEntity<?> getRoleDetail(@RequestParam Long roleId) {
         return ResponseEntity.ok(publisherManagerService.getRoleDetail(roleId));
     }
@@ -60,7 +76,7 @@ public class PublisherManagerController {
         return ResponseEntity.ok(publisherManagerService.createAccount(request));
     }
 
-    @PostMapping("/delete-account")
+    @DeleteMapping("/delete-account")
     @HasAuthority({PublisherAuthority.WRITE_MEMBERS})
     public ResponseEntity<?> deleteAccount(@RequestParam Long accountId) {
         publisherManagerService.deleteAccount(accountId);
@@ -73,11 +89,10 @@ public class PublisherManagerController {
         return ResponseEntity.ok(publisherManagerService.createNewCustomRole(request));
     }
 
-    @PostMapping("/role/update-role/{roleId}")
+    @PostMapping("/role/update-role")
     @HasAuthority({PublisherAuthority.WRITE_MEMBERS})
-    public ResponseEntity<?> updateCustomRole(@RequestBody @Valid CreateCustomRoleRequest request,
-                                              @PathVariable Long roleId) {
-        return ResponseEntity.ok(publisherManagerService.updateRole(roleId, request));
+    public ResponseEntity<?> updateCustomRole(@RequestBody @Valid CreateCustomRoleRequest request) {
+        return ResponseEntity.ok(publisherManagerService.updateRole(request));
     }
 
     @PostMapping("/role/change-status")

--- a/src/main/java/com/bravos/steak/dev/entity/PublisherPermissionGroup.java
+++ b/src/main/java/com/bravos/steak/dev/entity/PublisherPermissionGroup.java
@@ -22,7 +22,7 @@ public class PublisherPermissionGroup {
 
     String description;
 
-    @OneToMany(mappedBy = "permissionGroup", cascade = CascadeType.DETACH, fetch = FetchType.EAGER)
+    @OneToMany(mappedBy = "permissionGroup", cascade = CascadeType.DETACH, fetch = FetchType.LAZY)
     List<PublisherPermission> publisherPermissionList;
 
 }

--- a/src/main/java/com/bravos/steak/dev/entity/gamesubmission/BuildInfo.java
+++ b/src/main/java/com/bravos/steak/dev/entity/gamesubmission/BuildInfo.java
@@ -24,4 +24,7 @@ public class BuildInfo {
     @Field("checksum")
     private String checksum;
 
+    @Field("fileSize")
+    private Long fileSize;
+
 }

--- a/src/main/java/com/bravos/steak/dev/model/request/CreateCustomRoleRequest.java
+++ b/src/main/java/com/bravos/steak/dev/model/request/CreateCustomRoleRequest.java
@@ -1,6 +1,7 @@
 package com.bravos.steak.dev.model.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
 
@@ -13,6 +14,9 @@ import static lombok.AccessLevel.PRIVATE;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CreateCustomRoleRequest {
+
+    @NotNull(message = "Role ID cannot be null")
+    Long roleId;
 
     @NotBlank(message = "Role name cannot be blank")
     String name;

--- a/src/main/java/com/bravos/steak/dev/model/request/UpdatePreBuildRequest.java
+++ b/src/main/java/com/bravos/steak/dev/model/request/UpdatePreBuildRequest.java
@@ -30,4 +30,7 @@ public class UpdatePreBuildRequest {
     @NotBlank
     private String checksum;
 
+    @NotNull
+    private Long fileSize;
+
 }

--- a/src/main/java/com/bravos/steak/dev/model/response/GroupPermissionItem.java
+++ b/src/main/java/com/bravos/steak/dev/model/response/GroupPermissionItem.java
@@ -1,0 +1,26 @@
+package com.bravos.steak.dev.model.response;
+
+import java.util.List;
+
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@FieldDefaults(level = PRIVATE)
+public class GroupPermissionItem {
+
+    Long id;
+
+    String name;
+
+    String description;
+
+    List<PublisherPermissionListItem> permissions;
+
+}

--- a/src/main/java/com/bravos/steak/dev/model/response/PublisherPermissionListItem.java
+++ b/src/main/java/com/bravos/steak/dev/model/response/PublisherPermissionListItem.java
@@ -1,0 +1,22 @@
+package com.bravos.steak.dev.model.response;
+
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@FieldDefaults(level = PRIVATE)
+public class PublisherPermissionListItem {
+
+    Long id;
+
+    String name;
+
+    String description;
+
+}

--- a/src/main/java/com/bravos/steak/dev/repo/PublisherAccountRepository.java
+++ b/src/main/java/com/bravos/steak/dev/repo/PublisherAccountRepository.java
@@ -22,12 +22,32 @@ public interface PublisherAccountRepository extends JpaRepository<PublisherAccou
     @Query("SELECT new com.bravos.steak.dev.model.response.PublisherAccountListItem(" +
             "p.id, p.username, p.email) " +
             "FROM PublisherAccount p " +
-            "WHERE p.status = :status")
-    Page<PublisherAccountListItem> findAllByStatus(@Param("status") AccountStatus status, Pageable pageable);
+            "WHERE p.status = :status and p.publisher.id = :publisherId")
+    Page<PublisherAccountListItem> findAllByStatus(@Param("status") AccountStatus status,
+                                                   @Param("publisherId") Long publisherId,
+                                                   Pageable pageable);
 
     @Query("SELECT new com.bravos.steak.dev.model.response.PublisherAccountListItem(" +
             "p.id, p.username, p.email) " +
-            "FROM PublisherAccount p")
-    Page<PublisherAccountListItem> findAllz(Pageable pageable);
+            "FROM PublisherAccount p " +
+            "WHERE p.publisher.id = :publisherId")
+    Page<PublisherAccountListItem> findAllz(@Param("publisherId") Long publisherId, Pageable pageable);
+
+    @Query("SELECT new com.bravos.steak.dev.model.response.PublisherAccountListItem(" +
+            "p.id, p.username, p.email) " +
+            "FROM PublisherAccount p " +
+            "WHERE p.username LIKE %:keyword% and p.status = :status and p.publisher.id = :publisherId")
+    Page<PublisherAccountListItem> searchByUsername(@Param("keyword") String keyword,
+                                                    @Param("status") AccountStatus status,
+                                                    @Param("publisherId") Long publisherId,
+                                                    Pageable pageable);
+
+    @Query("SELECT new com.bravos.steak.dev.model.response.PublisherAccountListItem(" +
+            "p.id, p.username, p.email) " +
+            "FROM PublisherAccount p " +
+            "WHERE p.username LIKE %:keyword% and p.publisher.id = :publisherId")
+    Page<PublisherAccountListItem> searchByUsername(@Param("keyword") String keyword,
+                                                    @Param("publisherId") Long publisherId,
+                                                    Pageable pageable);
 
 }

--- a/src/main/java/com/bravos/steak/dev/repo/PublisherPermissionGroupRepository.java
+++ b/src/main/java/com/bravos/steak/dev/repo/PublisherPermissionGroupRepository.java
@@ -1,0 +1,18 @@
+package com.bravos.steak.dev.repo;
+
+import com.bravos.steak.dev.entity.PublisherPermissionGroup;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PublisherPermissionGroupRepository extends JpaRepository<PublisherPermissionGroup, Long> {
+
+    @Query("SELECT ppg FROM PublisherPermissionGroup ppg")
+    @EntityGraph(attributePaths = {"publisherPermissionList"})
+    List<PublisherPermissionGroup> findAllAndDetails();
+
+}

--- a/src/main/java/com/bravos/steak/dev/repo/PublisherPermissionRepository.java
+++ b/src/main/java/com/bravos/steak/dev/repo/PublisherPermissionRepository.java
@@ -2,13 +2,17 @@ package com.bravos.steak.dev.repo;
 
 import com.bravos.steak.dev.entity.PublisherPermission;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
 
+@Repository
 public interface PublisherPermissionRepository extends JpaRepository<PublisherPermission, Long> {
+
     Set<PublisherPermission> findAllByIdIn(Collection<Long> ids);
 
     Optional<PublisherPermission> findByName(String name);
+
 }

--- a/src/main/java/com/bravos/steak/dev/service/PublisherManagerService.java
+++ b/src/main/java/com/bravos/steak/dev/service/PublisherManagerService.java
@@ -2,10 +2,7 @@ package com.bravos.steak.dev.service;
 
 import com.bravos.steak.dev.model.request.CreateCustomRoleRequest;
 import com.bravos.steak.dev.model.request.CreatePublisherAccountRequest;
-import com.bravos.steak.dev.model.response.PublisherAccountDetail;
-import com.bravos.steak.dev.model.response.PublisherAccountListItem;
-import com.bravos.steak.dev.model.response.RoleDetail;
-import com.bravos.steak.dev.model.response.RoleListItem;
+import com.bravos.steak.dev.model.response.*;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
@@ -13,6 +10,11 @@ import java.util.List;
 public interface PublisherManagerService {
 
     Page<PublisherAccountListItem> getPublisherAccounts(int page, int size, String status);
+
+    Page<PublisherAccountListItem> searchPublisherAccounts(String keyword, String status,
+                                                           int page, int size);
+
+    List<GroupPermissionItem> getPublisherPermissions();
 
     List<RoleListItem> getCustomRoleList();
 
@@ -26,7 +28,7 @@ public interface PublisherManagerService {
 
     RoleDetail createNewCustomRole(CreateCustomRoleRequest request);
 
-    RoleDetail updateRole(Long roleId, CreateCustomRoleRequest request);
+    RoleDetail updateRole(CreateCustomRoleRequest request);
 
     void changeRoleStatus(Long roleId, Boolean isActive);
 

--- a/src/main/java/com/bravos/steak/dev/service/impl/GameSubmissionServiceImpl.java
+++ b/src/main/java/com/bravos/steak/dev/service/impl/GameSubmissionServiceImpl.java
@@ -166,6 +166,7 @@ public class GameSubmissionServiceImpl implements GameSubmissionService {
         buildInfo.setVersionName(updatePreBuildRequest.getVersionName());
         buildInfo.setExecPath(updatePreBuildRequest.getExecPath());
         buildInfo.setDownloadUrl(updatePreBuildRequest.getDownloadUrl());
+        buildInfo.setFileSize(updatePreBuildRequest.getFileSize());
         buildInfo.setChecksum(updatePreBuildRequest.getChecksum());
 
         gameSubmission.setBuildInfo(buildInfo);

--- a/src/main/java/com/bravos/steak/store/entity/GameVersion.java
+++ b/src/main/java/com/bravos/steak/store/entity/GameVersion.java
@@ -36,6 +36,10 @@ public class GameVersion {
 
     Long releaseDate;
 
+    Long fileSize;
+
+    String checksum;
+
     @Builder.Default
     Long createdAt = DateTimeHelper.currentTimeMillis();
 

--- a/src/main/java/com/bravos/steak/store/model/response/DownloadResponse.java
+++ b/src/main/java/com/bravos/steak/store/model/response/DownloadResponse.java
@@ -1,0 +1,26 @@
+package com.bravos.steak.store.model.response;
+
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@FieldDefaults(level = PRIVATE)
+public class DownloadResponse {
+
+    String downloadUrl;
+
+    String fileName;
+
+    String execPath;
+
+    String checksum;
+
+    Long fileSize;
+
+}

--- a/src/main/java/com/bravos/steak/store/repo/GameVersionRepository.java
+++ b/src/main/java/com/bravos/steak/store/repo/GameVersionRepository.java
@@ -2,6 +2,18 @@ package com.bravos.steak.store.repo;
 
 import com.bravos.steak.store.entity.GameVersion;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface GameVersionRepository extends JpaRepository<GameVersion, Long> {
+
+    @Query("SELECT gv FROM GameVersion gv " +
+            "WHERE gv.game.id = :gameId and gv.releaseDate <= :current and gv.status = 1 " +
+            "ORDER BY gv.releaseDate DESC " +
+            "LIMIT 1")
+    GameVersion findLatestGameVersionByGameId(@Param("gameId") Long gameId,
+                                              @Param("current") Long currentTimeMillis);
+
 }

--- a/src/main/java/com/bravos/steak/store/service/GameService.java
+++ b/src/main/java/com/bravos/steak/store/service/GameService.java
@@ -2,11 +2,14 @@ package com.bravos.steak.store.service;
 
 import com.bravos.steak.store.model.enums.GameStatus;
 import com.bravos.steak.store.model.response.CursorResponse;
+import com.bravos.steak.store.model.response.DownloadResponse;
 import com.bravos.steak.store.model.response.GameListItem;
 import com.bravos.steak.store.model.response.GameStoreDetail;
 
 public interface GameService {
+
     CursorResponse<GameListItem> getGameStoreList(Long cursor, int pageSize);
+
     CursorResponse<GameListItem> getFilteredGames(
             Long cursor,
             Long minPrice,
@@ -15,4 +18,7 @@ public interface GameService {
     );
 
     GameStoreDetail getGameStoreDetails(Long gameId);
+
+    DownloadResponse getGameDownloadUrl(Long gameId);
+
 }


### PR DESCRIPTION
This pull request introduces several changes across the codebase, focusing on database schema updates, enhancements to the `PublisherManagerController`, improvements to Redis service functionality, and the addition of new models and repositories. Below is a summary of the most important changes grouped by theme.

### Database Schema Updates:
* Added a new `file_size` column to the `game_version` table to store the size of game files (`migrations/20250723160127_add-file-size-to-game-version.sql`, `schema.pg.hcl`). [[1]](diffhunk://#diff-f4a2b6e03ba84a3b62c77a26c0c94b7710e5798e4a0c7c5847ed306585f04ad7R1-R2) [[2]](diffhunk://#diff-c069c30294b8e0404a369d48975208cb3a2f8c2ce93f3c66fa22ce829b2eab83R153-R156)
* Removed the `GAME CONTENT MANAGEMENT` permission group from the `publisher_permission_group` table (`migrations/20250723093841.sql`).

### Backend Enhancements:
* Added two new endpoints in `PublisherManagerController`:
  - `/accounts/search` for searching publisher accounts by keyword and status.
  - `/permissions` for retrieving publisher permissions (`PublisherManagerController.java`). [[1]](diffhunk://#diff-09182f79f22a3bc5c9b9d6dcdfb7e28281438031725c2cddccfc23cf0bf6202aR33-R48) [[2]](diffhunk://#diff-09182f79f22a3bc5c9b9d6dcdfb7e28281438031725c2cddccfc23cf0bf6202aL52-R68)
* Changed HTTP methods for some endpoints in `PublisherManagerController` to better align with REST conventions (e.g., `@PostMapping` to `@DeleteMapping` for `/delete-account`) and simplified the `updateCustomRole` endpoint by removing the `roleId` path variable. [[1]](diffhunk://#diff-09182f79f22a3bc5c9b9d6dcdfb7e28281438031725c2cddccfc23cf0bf6202aL63-R79) [[2]](diffhunk://#diff-09182f79f22a3bc5c9b9d6dcdfb7e28281438031725c2cddccfc23cf0bf6202aL76-R95)

### Redis Service Improvements:
* Introduced a new method `get(String key, CollectionLikeType type, Class<T> clazz)` in `RedisService` and its implementation to support fetching collections from Redis (`RedisService.java`, `RedisServiceImpl.java`). [[1]](diffhunk://#diff-3a4b866bd0bf3232c839311c8a10766dc1c9c31428ffa3cbc4f0edd74efdd2f0R24-R25) [[2]](diffhunk://#diff-bc7c50c953f6f9104ee19ea51fdd8576769352f7df6772bb7a241a26a150bc40R93-R104)

### New Models and Repositories:
* Added `GroupPermissionItem` and `PublisherPermissionListItem` response models to represent permissions and groups (`GroupPermissionItem.java`, `PublisherPermissionListItem.java`). [[1]](diffhunk://#diff-f8f4cd827c9fd778309d037142609e2751c6c9d4f29038dbf58f805f60d7109cR1-R26) [[2]](diffhunk://#diff-ae3f8c9ff7c37d8fa93ec2274c860a6db48fe62c9f82952f91745452eebbb741R1-R22)
* Created the `PublisherPermissionGroupRepository` to fetch permission groups with their associated permissions (`PublisherPermissionGroupRepository.java`).

### Miscellaneous Changes:
* Updated `BuildInfo` and related request models to include the `fileSize` property (`BuildInfo.java`, `UpdatePreBuildRequest.java`). [[1]](diffhunk://#diff-2f691b56db7d01a8b361b82f887251d30620aa2c06362d5ba10edf413cf344d6R27-R29) [[2]](diffhunk://#diff-81c4bbf9b2674feba1888d3b00b07a495f5332bf2209c71c67c2e4c4cfda32f7R33-R35)
* Adjusted the fetch type for `publisherPermissionList` in `PublisherPermissionGroup` from `EAGER` to `LAZY` to improve performance (`PublisherPermissionGroup.java`).