### PR TITLE
update-migration

### DIFF
--- a/migrations/20250724144412_add-checksum-column-to-gversion.sql
+++ b/migrations/20250724144412_add-checksum-column-to-gversion.sql
@@ -1,0 +1,2 @@
+-- Modify "game_version" table
+ALTER TABLE "public"."game_version" ADD COLUMN "checksum" character varying(64) NULL;

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:6FCih9pTznstqinTuallj32HHY4gHNFGf4rwrW1la/Q=
+h1:hRkUlyJuR/emqwcR9v29CERdYcvAo3GUbzXUI79cAn0=
 20250706170756_migrate-datetime-to-bigint.sql h1:5JrcN/MgdPa3aItd1d1933e6qfnTW8l6qRWiXP76nQQ=
 20250706170919_add-game-default-created-at.sql h1:8EqGnGq3gsxGa0YGT0c1Q9yxTXsUglQe9fSKYUP96Bo=
 20250706170931.sql h1:VdBUOWMkg+Ua82QGrSeIZ2luY6+z7Wr0LHjCTE1A5So=
@@ -8,3 +8,4 @@ h1:6FCih9pTznstqinTuallj32HHY4gHNFGf4rwrW1la/Q=
 20250720090202.sql h1:S09Q1sGMsdS8qIzYJzaPD3d+oj5MWrrSHja0WYLzzX8=
 20250723093841.sql h1:lO2YsSr/5e0FngyC/KsjV72bazJoOr+yS+bi0x8+Cdc=
 20250723160127_add-file-size-to-game-version.sql h1:0UA4S6FDbZW1s4F19k2tGi9Js9/R7SOHPg1sRuQeiGI=
+20250724144412_add-checksum-column-to-gversion.sql h1:MegKrQs6ipVXt10cuf0KcSv7wfWi/nmJmaBtH3JXjnA=

--- a/schema.pg.hcl
+++ b/schema.pg.hcl
@@ -154,6 +154,10 @@ table "game_version" {
     null = true
     type = bigint
   }
+  column "checksum" {
+    null = true
+    type = character_varying(64)
+  }
   column "release_date" {
     null = false
     type = bigint


### PR DESCRIPTION
This pull request introduces a new `checksum` column to the `game_version` table in the database schema. The changes include updates to the database migration files, schema definition, and the checksum file to reflect the addition.

### Database schema updates:
* [`migrations/20250724144412_add-checksum-column-to-gversion.sql`](diffhunk://#diff-e1124efbf95bcf7968e773e01246b771565b037e5462a9d9fa6c6cfd09ad177dR1-R2): Added a new `checksum` column of type `character varying(64)` to the `game_version` table.
* [`schema.pg.hcl`](diffhunk://#diff-c069c30294b8e0404a369d48975208cb3a2f8c2ce93f3c66fa22ce829b2eab83R157-R160): Updated the `game_version` table schema to include the new `checksum` column with a nullable constraint and `character_varying(64)` type.