### PR TITLE
fix-minor-bugs

### DIFF
--- a/src/main/java/com/bravos/steak/administration/service/impl/AdminUploadServiceImpl.java
+++ b/src/main/java/com/bravos/steak/administration/service/impl/AdminUploadServiceImpl.java
@@ -15,6 +15,7 @@ import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -110,7 +111,7 @@ public class AdminUploadServiceImpl implements AdminUploadService {
             Arrays.stream(deleteImageRequests)
                     .filter(request -> request != null && request.getUrl() != null)
                     .map(request -> extractObjectKey(request.getUrl()))
-                    .filter(objectKey -> objectKey != null)
+                    .filter(Objects::nonNull)
                     .forEach(this::deleteS3Object);
         });
     }

--- a/src/main/java/com/bravos/steak/useraccount/controller/UserProfileController.java
+++ b/src/main/java/com/bravos/steak/useraccount/controller/UserProfileController.java
@@ -3,10 +3,7 @@ package com.bravos.steak.useraccount.controller;
 import com.bravos.steak.useraccount.entity.UserProfile;
 import com.bravos.steak.useraccount.service.UserProfileService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/user/profile")


### PR DESCRIPTION
This pull request includes minor improvements to code readability and consistency. The changes primarily involve refactoring for cleaner code and simplifying imports.

### Code readability improvements:
* Replaced `objectKey -> objectKey != null` with `Objects::nonNull` in the `deleteAdminFile` method of `AdminUploadServiceImpl` to improve readability and leverage built-in Java utilities. (`src/main/java/com/bravos/steak/administration/service/impl/AdminUploadServiceImpl.java`, [src/main/java/com/bravos/steak/administration/service/impl/AdminUploadServiceImpl.javaL113-R114](diffhunk://#diff-0046ec98d1f6340a3b3b90cb530ca81617512c5c7df507449b65de868035cd8cL113-R114))

### Simplification of imports:
* Consolidated Spring Web annotations (`@GetMapping`, `@PostMapping`, etc.) into a single wildcard import in `UserProfileController` to simplify and reduce redundancy in imports. (`src/main/java/com/bravos/steak/useraccount/controller/UserProfileController.java`, [src/main/java/com/bravos/steak/useraccount/controller/UserProfileController.javaL6-R6](diffhunk://#diff-887a9c3d5225e2b5ccf71a2a55a670b2baacd1bef1e3557a66ccaa52fa580ac6L6-R6))
* Added `java.util.Objects` import in `AdminUploadServiceImpl` to support the use of `Objects::nonNull`. (`src/main/java/com/bravos/steak/administration/service/impl/AdminUploadServiceImpl.java`, [src/main/java/com/bravos/steak/administration/service/impl/AdminUploadServiceImpl.javaR18](diffhunk://#diff-0046ec98d1f6340a3b3b90cb530ca81617512c5c7df507449b65de868035cd8cR18))