### PR TITLE
upgrade-deploy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
             
             docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_PASSWORD }}
             docker pull bravos/steak-server:latest
-            docker run --memory="1.5g" -d -p 8888:8888 --name steak-server \
+            docker run -d -p 8888:8888 --name steak-server \
               -e AZURE_CLIENT_ID=${{ secrets.AZURE_CLIENT_ID }} \
               -e AZURE_CLIENT_SECRET=${{ secrets.AZURE_CLIENT_SECRET }} \
               -e AZURE_TENANT_ID=${{ secrets.AZURE_TENANT_ID }} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,5 @@ WORKDIR /app
 COPY --from=build /app/target/*.jar steak.jar
 COPY prod.env .env
 
-ENTRYPOINT ["java", "-Xms1300m", "-Xmx1300m", "-XX:+UseContainerSupport", "-Duser.timezone=GMT+7", "-jar", "steak.jar", "--spring.profiles.active=prod"]
+ENTRYPOINT ["java", "-Xms5g", "-Xmx5g", "-XX:+UseZGC", "-XX:+UseContainerSupport", "-Duser.timezone=GMT+7", "-jar", "steak.jar", "--spring.profiles.active=prod"]
 


### PR DESCRIPTION
This pull request updates the deployment configuration to allocate more memory and use a different garbage collector for the application, and removes memory limits from the Docker run command. The main goal is to improve performance by increasing available resources.

**Deployment configuration changes:**

* Increased Java heap size from 1.3GB to 5GB and switched the garbage collector to ZGC in the Docker `ENTRYPOINT` for better performance (`Dockerfile`).
* Removed the explicit 1.5GB memory limit from the `docker run` command in the GitHub Actions workflow, allowing the container to use more memory as needed (`.github/workflows/main.yml`).