### PR TITLE
Develop

### DIFF
--- a/src/main/java/com/bravos/steak/store/repo/GameRepository.java
+++ b/src/main/java/com/bravos/steak/store/repo/GameRepository.java
@@ -29,7 +29,7 @@ public interface GameRepository extends JpaRepository<Game, Long>, JpaSpecificat
 
     List<Game> findByStatusAndCreatedAtLessThanOrderByCreatedAtDesc(GameStatus status, Long cursor);
 
-    @Query("SELECT MAX(g.releaseDate) FROM Game g WHERE g.status = 0 AND g.releaseDate <= :current")
+    @Query("SELECT MAX(g.id) FROM Game g WHERE g.status = 0 AND g.releaseDate <= :current")
     Long getMaxCursorByStatus(Long current);
 
     @EntityGraph(type = EntityGraph.EntityGraphType.FETCH,

--- a/src/main/java/com/bravos/steak/store/service/impl/GameServiceImpl.java
+++ b/src/main/java/com/bravos/steak/store/service/impl/GameServiceImpl.java
@@ -177,11 +177,11 @@ public class GameServiceImpl implements GameService {
             Specification<Game> spec = GameSpecification.withoutFilters(cursor);
             List<Game> games = new ArrayList<>(gameRepository.findAll(spec, PageRequest.of(0, pageSize)).getContent());
             if (games.isEmpty()) return CursorResponse.empty();
-            games.sort(Comparator.comparing(Game::getReleaseDate).reversed());
+            games.sort(Comparator.comparing(Game::getId).reversed());
             List<CartGameInfo> gameDetails = gameDetailsRepository.findByIdIn(games.stream().map(Game::getId).toList());
             Map<Long,GameListItem> gameListItemMap = getGameListItemMap(games, gameDetails);
             Long maxCursor = getMaxCursorWithoutFilters();
-            Long currentCursor = games.getLast().getReleaseDate();
+            Long currentCursor = games.getLast().getId();
             if(maxCursor <= currentCursor) {
                 redisService.delete("cursor:non-filter");
                 maxCursor = getMaxCursorWithoutFilters();

--- a/src/main/java/com/bravos/steak/store/service/impl/GameServiceImpl.java
+++ b/src/main/java/com/bravos/steak/store/service/impl/GameServiceImpl.java
@@ -186,7 +186,7 @@ public class GameServiceImpl implements GameService {
                 redisService.delete("cursor:non-filter");
                 maxCursor = getMaxCursorWithoutFilters();
             }
-            boolean hasNextCursor = maxCursor != null && maxCursor >= currentCursor;
+            boolean hasNextCursor = maxCursor != null && maxCursor > currentCursor;
             return CursorResponse.<GameListItem>builder()
                     .items(gameListItemMap.values().stream().toList())
                     .maxCursor(maxCursor)

--- a/src/main/java/com/bravos/steak/store/specifications/GameSpecification.java
+++ b/src/main/java/com/bravos/steak/store/specifications/GameSpecification.java
@@ -25,12 +25,14 @@ public class GameSpecification {
             }
             List<Predicate> predicates = new ArrayList<>(2);
             long currentTime = DateTimeHelper.currentTimeMillis();
+
+            predicates.add(cb.lessThanOrEqualTo(root.get("releaseDate"), currentTime));
+
             if (cursor != null) {
-                predicates.add(cb.lessThan(root.get("releaseDate"), cursor > currentTime ? currentTime : cursor));
-            } else {
-                predicates.add(cb.lessThan(root.get("releaseDate"), currentTime));
+                predicates.add(cb.lessThan(root.get("id"), cursor));
             }
-            query.orderBy(cb.desc(root.get("releaseDate")));
+
+            query.orderBy(cb.desc(root.get("id")));
             predicates.add(cb.equal(root.get("status"), GameStatus.OPENING));
             return cb.and(predicates.toArray(new Predicate[0]));
         };


### PR DESCRIPTION
This pull request updates the cursor-based pagination logic for games, shifting from using `releaseDate` to using the game `id` as the cursor. This change affects how games are queried, ordered, and paginated throughout the repository and service layers, aiming to improve consistency and reliability in fetching paginated results.

**Pagination and Query Logic Updates:**

* Changed the main cursor field from `releaseDate` to `id` in the repository query, so the maximum cursor is now determined by the largest `id` of games matching the criteria (`GameRepository.java`).
* Updated the specification for querying games without filters to use `id` for pagination and ordering, instead of `releaseDate`, and adjusted predicates accordingly (`GameSpecification.java`).
* Modified the logic for determining if there is a next cursor in pagination to use a strict greater-than comparison (`maxCursor > currentCursor`), aligning with the new `id`-based cursor approach (`GameServiceImpl.java`).
This pull request updates the game listing and cursor logic to use the game's `id` field instead of the `releaseDate` field for pagination and sorting. This change impacts how games are retrieved, sorted, and how cursors are managed for paginated queries, making the system more robust against issues with non-unique or changing release dates.

**Cursor and Sorting Logic Updates:**

* Changed the sorting and pagination logic in `GameServiceImpl.java` to use `Game::getId` instead of `Game::getReleaseDate`, and updated cursor handling to use `id` for more reliable pagination.
* Updated the specification in `GameSpecification.java` to filter and order games by `id` instead of `releaseDate`, ensuring consistent ordering and cursor advancement.

**Repository Query Adjustment:**

* Modified the custom query in `GameRepository.java` to select the maximum `id` instead of maximum `releaseDate` for determining the cursor, aligning with the new pagination logic.