### PR TITLE
update-game-version-api

### DIFF
--- a/src/main/java/com/bravos/steak/dev/model/response/CurrentVersionInfo.java
+++ b/src/main/java/com/bravos/steak/dev/model/response/CurrentVersionInfo.java
@@ -3,8 +3,6 @@ package com.bravos.steak.dev.model.response;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
 
-import java.io.Serializable;
-
 import static lombok.AccessLevel.PRIVATE;
 
 @Getter
@@ -13,14 +11,14 @@ import static lombok.AccessLevel.PRIVATE;
 @AllArgsConstructor
 @Builder
 @FieldDefaults(level = PRIVATE)
-public class CurrentVersionInfo implements Serializable {
+public class CurrentVersionInfo {
 
     Long gameId;
 
     String title;
 
-    GameVersionListItem currentVersion;
+    String currentVersion;
 
-    GameVersionListItem nextVersion;
+    String nextVersion;
 
 }

--- a/src/main/java/com/bravos/steak/dev/service/impl/GameManagerServiceImpl.java
+++ b/src/main/java/com/bravos/steak/dev/service/impl/GameManagerServiceImpl.java
@@ -425,44 +425,20 @@ public class GameManagerServiceImpl implements GameManagerService {
         long now = DateTimeHelper.currentTimeMillis();
         GameVersion currentVersion = gameVersionRepository.findLatestGameVersionByGameId(gameId, now);
         GameVersion nextVersion = gameVersionRepository.findNextVersionByGameId(gameId, now);
-        GameVersionListItem currentVersionItem = null;
-        GameVersionListItem nextVersionItem = null;
+        String currentVersionName = null;
+        String nextVersionItem;
         if (currentVersion != null) {
-            currentVersionItem = GameVersionListItem.builder()
-                    .versionId(currentVersion.getId())
-                    .name(currentVersion.getName())
-                    .changeLog(currentVersion.getChangeLog())
-                    .execPath(currentVersion.getExecPath())
-                    .downloadUrl(currentVersion.getDownloadUrl())
-                    .status(currentVersion.getStatus())
-                    .releaseDate(currentVersion.getReleaseDate())
-                    .fileSize(currentVersion.getFileSize())
-                    .installSize(currentVersion.getInstallSize())
-                    .checksum(currentVersion.getChecksum())
-                    .createdAt(currentVersion.getCreatedAt())
-                    .updatedAt(currentVersion.getUpdatedAt())
-                    .build();
+            currentVersionName = currentVersion.getName();
         }
         if (nextVersion != null) {
-            nextVersionItem = GameVersionListItem.builder()
-                    .versionId(nextVersion.getId())
-                    .name(nextVersion.getName())
-                    .changeLog(nextVersion.getChangeLog())
-                    .execPath(nextVersion.getExecPath())
-                    .downloadUrl(nextVersion.getDownloadUrl())
-                    .status(nextVersion.getStatus())
-                    .releaseDate(nextVersion.getReleaseDate())
-                    .fileSize(nextVersion.getFileSize())
-                    .installSize(nextVersion.getInstallSize())
-                    .checksum(nextVersion.getChecksum())
-                    .createdAt(nextVersion.getCreatedAt())
-                    .updatedAt(nextVersion.getUpdatedAt())
-                    .build();
+            nextVersionItem = nextVersion.getName();
+        } else {
+            nextVersionItem = "No upcoming version";
         }
         return CurrentVersionInfo.builder()
                 .gameId(gameId)
                 .title(game.getName())
-                .currentVersion(currentVersionItem)
+                .currentVersion(currentVersionName)
                 .nextVersion(nextVersionItem)
                 .build();
     }


### PR DESCRIPTION
This pull request simplifies the way current and next game version information is represented and returned by the service. Instead of returning detailed `GameVersionListItem` objects, the code now provides just the version names (as strings), making the response lighter and easier to consume.

**Model simplification:**

* Changed the `CurrentVersionInfo` model to use `String` fields for `currentVersion` and `nextVersion` instead of `GameVersionListItem` objects, and removed the `Serializable` interface. (`src/main/java/com/bravos/steak/dev/model/response/CurrentVersionInfo.java`) [[1]](diffhunk://#diff-6749765a3c9e29eca95578327bfa2dd25b6c422960f14c87aae8f47d97e05f45L16-R22) [[2]](diffhunk://#diff-6749765a3c9e29eca95578327bfa2dd25b6c422960f14c87aae8f47d97e05f45L6-L7)

**Service logic update:**

* Updated `GameManagerServiceImpl.getGameCurrentVersion` to set `currentVersion` and `nextVersion` as strings containing the version names, rather than building full `GameVersionListItem` objects. If there is no next version, it now returns `"No upcoming version"` for `nextVersion`. (`src/main/java/com/bravos/steak/dev/service/impl/GameManagerServiceImpl.java`)