### PR TITLE
fix-vunerable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,12 @@
             <artifactId>reactor-netty-http</artifactId>
             <version>1.2.8</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/io.netty/netty-codec-http2 -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http2</artifactId>
+            <version>5.0.0.Alpha2</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-websocket</artifactId>


### PR DESCRIPTION
This pull request adds a new dependency to the project, specifically for HTTP/2 support. This change will allow the application to work with HTTP/2 protocols using Netty.

Dependency management:

* Added the `netty-codec-http2` dependency (version `5.0.0.Alpha2`) to `pom.xml` to enable HTTP/2 support in the application.