### PR TITLE
fix-ip-restriction

### DIFF
--- a/src/main/java/com/bravos/steak/common/service/auth/impl/SessionServiceImpl.java
+++ b/src/main/java/com/bravos/steak/common/service/auth/impl/SessionServiceImpl.java
@@ -52,7 +52,7 @@ public class SessionServiceImpl implements SessionService {
     @Override
     public String getUserIpAddress() {
         String realIp = httpServletRequest.getHeader("X-Real-IP");
-        return (realIp != null && !realIp.isEmpty()) ? realIp : httpServletRequest.getRemoteAddr();
+        return realIp == null ? null : realIp.trim();
     }
 
     @Override

--- a/src/main/java/com/bravos/steak/store/service/impl/DownloadGameServiceImpl.java
+++ b/src/main/java/com/bravos/steak/store/service/impl/DownloadGameServiceImpl.java
@@ -3,6 +3,7 @@ package com.bravos.steak.store.service.impl;
 import com.bravos.steak.common.model.CdnKeyPair;
 import com.bravos.steak.common.model.GameS3Config;
 import com.bravos.steak.store.service.DownloadGameService;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import software.amazon.awssdk.services.cloudfront.CloudFrontUtilities;
@@ -11,6 +12,7 @@ import software.amazon.awssdk.services.cloudfront.url.SignedUrl;
 
 import java.time.Instant;
 
+@Slf4j
 @Service
 public class DownloadGameServiceImpl implements DownloadGameService {
 
@@ -33,9 +35,10 @@ public class DownloadGameServiceImpl implements DownloadGameService {
                 .keyPairId(cdnKeyPair.getKeyPairId())
                 .privateKey(cdnKeyPair.getPrivateKey())
                 .expirationDate(expirationTime)
+                .ipRange(ipAddress + "/32")
                 .build();
-
         SignedUrl signedUrl = cloudFrontUtilities.getSignedUrlWithCustomPolicy(customSignerRequest);
+        log.info("Request to download game from IP: {}", ipAddress);
         return signedUrl.url();
     }
 


### PR DESCRIPTION
This pull request introduces improvements to IP address handling and logging in the game download service, as well as a minor change to how user IP addresses are retrieved in session management. The main focus is on restricting download URLs to specific IPs and adding logging for download requests.

**Game Download Service Improvements:**

* Added the `@Slf4j` annotation to `DownloadGameServiceImpl` and imported the required logging library, enabling structured logging throughout the class. [[1]](diffhunk://#diff-59d9337043dac7d93d344019e9c5be584d6aacb8c7b473f4fce660c22820e1b6R6) [[2]](diffhunk://#diff-59d9337043dac7d93d344019e9c5be584d6aacb8c7b473f4fce660c22820e1b6R15)
* Modified the `getGameDownloadUrl` method to restrict the signed CloudFront URL to the requesting IP address by setting the `ipRange` field, enhancing security.
* Added a log statement to record the IP address requesting a game download, improving traceability and monitoring.

**Session Service Change:**

* Updated the `getUserIpAddress` method to trim whitespace from the `X-Real-IP` header and return `null` if the header is missing, instead of falling back to `getRemoteAddr`. This may affect how user IPs are captured in some scenarios.