### PR TITLE
fix-ip-restriction

### DIFF
--- a/src/main/java/com/bravos/steak/store/service/impl/DownloadGameServiceImpl.java
+++ b/src/main/java/com/bravos/steak/store/service/impl/DownloadGameServiceImpl.java
@@ -35,7 +35,7 @@ public class DownloadGameServiceImpl implements DownloadGameService {
                 .keyPairId(cdnKeyPair.getKeyPairId())
                 .privateKey(cdnKeyPair.getPrivateKey())
                 .expirationDate(expirationTime)
-                .ipRange(ipAddress + "/32")
+//                .ipRange(ipAddress + "/32")
                 .build();
         SignedUrl signedUrl = cloudFrontUtilities.getSignedUrlWithCustomPolicy(customSignerRequest);
         log.info("Request to download game from IP: {}", ipAddress);

--- a/src/main/java/com/bravos/steak/store/service/impl/DownloadGameServiceImpl.java
+++ b/src/main/java/com/bravos/steak/store/service/impl/DownloadGameServiceImpl.java
@@ -35,7 +35,7 @@ public class DownloadGameServiceImpl implements DownloadGameService {
                 .keyPairId(cdnKeyPair.getKeyPairId())
                 .privateKey(cdnKeyPair.getPrivateKey())
                 .expirationDate(expirationTime)
-//                .ipRange(ipAddress + "/32")
+                .ipRange(ipAddress + "/32")
                 .build();
         SignedUrl signedUrl = cloudFrontUtilities.getSignedUrlWithCustomPolicy(customSignerRequest);
         log.info("Request to download game from IP: {}", ipAddress);

--- a/src/main/java/com/bravos/steak/useraccount/service/impl/UserAuthService.java
+++ b/src/main/java/com/bravos/steak/useraccount/service/impl/UserAuthService.java
@@ -148,7 +148,7 @@ public class UserAuthService extends AuthService {
 
     private Account googleOauthLogin(OauthLoginRequest oauthLoginRequest) {
         try {
-            String code = URLDecoder.decode(oauthLoginRequest.getCode(), StandardCharsets.UTF_8);
+            String code = oauthLoginRequest.getCode();
             OAuth2AccessToken accessToken = googleOauthService.getAccessToken(code);
             OAuthRequest request = new OAuthRequest(Verb.GET, GOOGLE_OAUTH_LOGIN_URL);
             googleOauthService.signRequest(accessToken, request);


### PR DESCRIPTION
This pull request makes a minor change to the way signed URLs are generated for game downloads in `DownloadGameServiceImpl.java`. The change comments out the line that restricts the signed URL to a specific IP address, allowing downloads from any IP instead of just the requesting IP.

* Removed IP address restriction from signed URL generation by commenting out the `.ipRange(ipAddress + "/32")` line in `DownloadGameServiceImpl.java`.