### PR TITLE
add-debug-oauth2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ WORKDIR /app
 COPY --from=build /app/target/*.jar steak.jar
 COPY prod.env .env
 
-ENTRYPOINT ["java", "-Xms5g", "-Xmx5g", "-XX:+UseZGC", "-XX:+ZGenerational", "-XX:+UseContainerSupport", "-Duser.timezone=GMT+7", "-jar", "steak.jar", "--spring.profiles.active=prod"]
+ENTRYPOINT ["java", "-Xms5g", "-Xmx5g", "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005", "-XX:+UseZGC", "-XX:+ZGenerational", "-XX:+UseContainerSupport", "-Duser.timezone=GMT+7", "-jar", "steak.jar", "--spring.profiles.active=prod"]

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,12 @@
             <artifactId>reactor-netty-http</artifactId>
             <version>1.3.0-M6</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/io.netty/netty-codec-http2 -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http2</artifactId>
+            <version>4.2.4.Final</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-websocket</artifactId>

--- a/src/main/java/com/bravos/steak/useraccount/service/impl/UserAuthService.java
+++ b/src/main/java/com/bravos/steak/useraccount/service/impl/UserAuthService.java
@@ -36,12 +36,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
-import java.io.IOException;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.ExecutionException;
 
 @Slf4j
 @Service("userAuthService")
@@ -159,7 +155,7 @@ public class UserAuthService extends AuthService {
             }
             return handleOauth2Login(oauthLoginRequest, "google", googleOauthResponse.getSub(),
                     googleOauthResponse.getName(), googleOauthResponse.getEmail(), googleOauthResponse.getPicture());
-        } catch (IOException | InterruptedException | ExecutionException e) {
+        } catch (Exception e) {
             log.error("Error during Google OAuth login: ", e);
             throw new BadRequestException("Error during Google OAuth login: " + e.getMessage());
         }
@@ -177,7 +173,7 @@ public class UserAuthService extends AuthService {
             }
             return handleOauth2Login(oauthLoginRequest, "github", String.valueOf(githubOauthResponse.getId()),
                     githubOauthResponse.getLogin(), githubOauthResponse.getEmail(), githubOauthResponse.getAvatar_url());
-        } catch (IOException | ExecutionException | InterruptedException e) {
+        } catch (Exception e) {
             log.error("Error during GitHub OAuth login: ", e);
             throw new BadRequestException("Error during GitHub OAuth login: " + e.getMessage());
         }


### PR DESCRIPTION
This pull request introduces improvements for debugging and dependency management, as well as code cleanup and simplification in the authentication service. The most notable changes are the addition of remote debugging support in the Docker configuration, a new HTTP/2 codec dependency, and streamlined exception handling in OAuth login methods.

**Docker and Dependency Updates:**

* Added JVM remote debugging support to the `ENTRYPOINT` in `Dockerfile` by including the `-agentlib:jdwp` option, enabling remote debugging on port 5005.
* Added a new dependency `netty-codec-http2` (version 4.2.4.Final) to `pom.xml` to support HTTP/2 features.

**Code Cleanup and Simplification:**

* Removed unused imports from `UserAuthService.java` to clean up the codebase.
* Simplified exception handling in both `googleOauthLogin` and `githubOauthLogin` methods by catching a generic `Exception` instead of multiple specific exceptions, making the code easier to maintain. [[1]](diffhunk://#diff-3eb2e15a6961f58f7a2154ebf75e4e49b42d1281d8c777a1ee90bb569cd7ef25L162-R158) [[2]](diffhunk://#diff-3eb2e15a6961f58f7a2154ebf75e4e49b42d1281d8c777a1ee90bb569cd7ef25L180-R176)