### PR TITLE
fix-oauth2-bugs

### DIFF
--- a/src/main/java/com/bravos/steak/common/configuration/OauthConfiguration.java
+++ b/src/main/java/com/bravos/steak/common/configuration/OauthConfiguration.java
@@ -21,16 +21,9 @@ public class OauthConfiguration {
 
     @Bean(name = "googleOauthService")
     public OAuth20Service googleOauthService() {
-        String profile = System.getProperty("spring.profiles.active");
-        String clientId = profile.equals("dev") ?
-                System.getProperty("GOOGLE_CLIENT_ID") : keyVaultService.getSecretKey(System.getProperty("GOOGLE_CLIENT_ID"));
-        String apiSecret = profile.equals("dev") ?
-                System.getProperty("GOOGLE_API_SECRET") : keyVaultService.getSecretKey(System.getProperty("GOOGLE_API_SECRET"));
-        String callbackUrl = profile.equals("dev") ?
-                System.getProperty("GOOGLE_CALLBACK_URL") : keyVaultService.getSecretKey(System.getProperty("GOOGLE_CALLBACK_URL"));
-        log.info("Google OAuth Service initialized with clientId: {}", clientId);
-        log.info("Google OAuth Service initialized with callbackUrl: {}", callbackUrl);
-        log.info("Google OAuth Service initialized with apiSecret: {}", apiSecret);
+        String clientId = keyVaultService.getSecretKey(System.getProperty("GOOGLE_CLIENT_ID"));
+        String apiSecret = keyVaultService.getSecretKey(System.getProperty("GOOGLE_API_SECRET"));
+        String callbackUrl = keyVaultService.getSecretKey(System.getProperty("GOOGLE_CALLBACK_URL"));
         return new ServiceBuilder(clientId)
                 .apiSecret(apiSecret)
                 .callback(callbackUrl)
@@ -40,16 +33,9 @@ public class OauthConfiguration {
 
     @Bean(name = "githubOauthService")
     public OAuth20Service gihubOauthService() {
-        String profile = System.getProperty("spring.profiles.active");
-        String clientId = profile.equals("dev") ?
-                System.getProperty("GITHUB_CLIENT_ID") : keyVaultService.getSecretKey(System.getProperty("GITHUB_CLIENT_ID"));
-        String apiSecret = profile.equals("dev") ?
-                System.getProperty("GITHUB_API_SECRET") : keyVaultService.getSecretKey(System.getProperty("GITHUB_API_SECRET"));
-        String callbackUrl = profile.equals("dev") ?
-                System.getProperty("GITHUB_CALLBACK_URL") : keyVaultService.getSecretKey(System.getProperty("GITHUB_CALLBACK_URL"));
-        log.info("GitHub OAuth Service initialized with clientId: {}", clientId);
-        log.info("GitHub OAuth Service initialized with callbackUrl: {}", callbackUrl);
-        log.info("GitHub OAuth Service initialized with apiSecret: {}", apiSecret);
+        String clientId = keyVaultService.getSecretKey(System.getProperty("GITHUB_CLIENT_ID"));
+        String apiSecret = keyVaultService.getSecretKey(System.getProperty("GITHUB_API_SECRET"));
+        String callbackUrl = keyVaultService.getSecretKey(System.getProperty("GITHUB_CALLBACK_URL"));
         return new ServiceBuilder(clientId)
                 .apiSecret(apiSecret)
                 .callback(callbackUrl)

--- a/src/main/java/com/bravos/steak/useraccount/service/impl/UserAuthService.java
+++ b/src/main/java/com/bravos/steak/useraccount/service/impl/UserAuthService.java
@@ -145,11 +145,7 @@ public class UserAuthService extends AuthService {
     private Account googleOauthLogin(OauthLoginRequest oauthLoginRequest) {
         try {
             String code = oauthLoginRequest.getCode();
-            log.info(googleOauthService.getAuthorizationUrl());
-            log.info(googleOauthService.getApiKey());
-            log.info(googleOauthService.getApiSecret());
             OAuth2AccessToken accessToken = googleOauthService.getAccessToken(code);
-            log.info("Access token: {}",accessToken.getAccessToken());
             OAuthRequest request = new OAuthRequest(Verb.GET, GOOGLE_OAUTH_LOGIN_URL);
             googleOauthService.signRequest(accessToken, request);
             String response = googleOauthService.execute(request).getBody();


### PR DESCRIPTION
This pull request refactors the OAuth configuration and login logic to improve security and simplify the code. The main change is the removal of development-specific logic for fetching secrets, ensuring all OAuth credentials are consistently retrieved from the key vault. Additionally, unnecessary logging of sensitive information has been removed from the authentication flow.

### OAuth configuration changes

* Removed logic that used plain environment variables for OAuth credentials in the `googleOauthService` and `githubOauthService` beans; now, all credentials are fetched from `keyVaultService` regardless of environment. [[1]](diffhunk://#diff-b9e5db17945154117e26332b3bb8e54f1771689103f7709116173e41c9a41b4eL24-R26) [[2]](diffhunk://#diff-b9e5db17945154117e26332b3bb8e54f1771689103f7709116173e41c9a41b4eL43-R38)

### Security and logging improvements

* Removed logging of sensitive OAuth credentials and access tokens in the `googleOauthLogin` method in `UserAuthService.java`.