### PR TITLE
update-game-filter

### DIFF
--- a/migrations/20250817105908_trending-procedure.sql
+++ b/migrations/20250817105908_trending-procedure.sql
@@ -1,0 +1,172 @@
+CREATE OR REPLACE FUNCTION proc_weekly_trending()
+    RETURNS TABLE(
+                     game_id BIGINT,
+                     peak_concurrent BIGINT,
+                     avg_concurrent NUMERIC(12,2),
+                     growth_rate NUMERIC(6,2),
+                     trending_score NUMERIC(12,2)
+                 )
+    LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN QUERY
+        WITH peak AS (
+            SELECT game_id, MAX(count) AS peak_concurrent
+            FROM playing_count_record
+            WHERE record_at >= EXTRACT(EPOCH FROM (NOW() - INTERVAL '7 days')) * 1000
+            GROUP BY game_id
+        ),
+             avg_play AS (
+                 SELECT game_id, AVG(count) AS avg_concurrent
+                 FROM playing_count_record
+                 WHERE record_at >= EXTRACT(EPOCH FROM (NOW() - INTERVAL '7 days')) * 1000
+                 GROUP BY game_id
+             ),
+             growth AS (
+                 SELECT t.game_id,
+                        CASE
+                            WHEN l.avg_last > 0 THEN (t.avg_this - l.avg_last) / l.avg_last
+                            ELSE 1
+                            END AS growth_rate
+                 FROM (
+                          SELECT game_id, AVG(count) AS avg_this
+                          FROM playing_count_record
+                          WHERE record_at >= EXTRACT(EPOCH FROM (NOW() - INTERVAL '7 days')) * 1000
+                          GROUP BY game_id
+                      ) t
+                          LEFT JOIN (
+                     SELECT game_id, AVG(count) AS avg_last
+                     FROM playing_count_record
+                     WHERE record_at >= EXTRACT(EPOCH FROM (NOW() - INTERVAL '14 days')) * 1000
+                       AND record_at < EXTRACT(EPOCH FROM (NOW() - INTERVAL '7 days')) * 1000
+                     GROUP BY game_id
+                 ) l ON t.game_id = l.game_id
+             )
+        SELECT p.game_id,
+               p.peak_concurrent,
+               a.avg_concurrent,
+               g.growth_rate,
+               (p.peak_concurrent * 0.4) + (a.avg_concurrent * 0.4) + (COALESCE(g.growth_rate,0) * 100 * 0.2) AS trending_score
+        FROM peak p
+                 JOIN avg_play a ON p.game_id = a.game_id
+                 LEFT JOIN growth g ON p.game_id = g.game_id
+        ORDER BY trending_score DESC
+        LIMIT 50;
+END;
+$$;
+
+
+CREATE OR REPLACE FUNCTION proc_monthly_trending()
+    RETURNS TABLE(
+                     game_id BIGINT,
+                     peak_concurrent BIGINT,
+                     avg_concurrent NUMERIC(12,2),
+                     growth_rate NUMERIC(6,2),
+                     trending_score NUMERIC(12,2)
+                 )
+    LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN QUERY
+        WITH peak AS (
+            SELECT game_id, MAX(count) AS peak_concurrent
+            FROM playing_count_record
+            WHERE record_at >= EXTRACT(EPOCH FROM (NOW() - INTERVAL '30 days')) * 1000
+            GROUP BY game_id
+        ),
+             avg_play AS (
+                 SELECT game_id, AVG(count) AS avg_concurrent
+                 FROM playing_count_record
+                 WHERE record_at >= EXTRACT(EPOCH FROM (NOW() - INTERVAL '30 days')) * 1000
+                 GROUP BY game_id
+             ),
+             growth AS (
+                 SELECT t.game_id,
+                        CASE
+                            WHEN l.avg_last > 0 THEN (t.avg_this - l.avg_last) / l.avg_last
+                            ELSE 1
+                            END AS growth_rate
+                 FROM (
+                          SELECT game_id, AVG(count) AS avg_this
+                          FROM playing_count_record
+                          WHERE record_at >= EXTRACT(EPOCH FROM (NOW() - INTERVAL '30 days')) * 1000
+                          GROUP BY game_id
+                      ) t
+                          LEFT JOIN (
+                     SELECT game_id, AVG(count) AS avg_last
+                     FROM playing_count_record
+                     WHERE record_at >= EXTRACT(EPOCH FROM (NOW() - INTERVAL '60 days')) * 1000
+                       AND record_at < EXTRACT(EPOCH FROM (NOW() - INTERVAL '30 days')) * 1000
+                     GROUP BY game_id
+                 ) l ON t.game_id = l.game_id
+             )
+        SELECT p.game_id,
+               p.peak_concurrent,
+               a.avg_concurrent,
+               g.growth_rate,
+               (p.peak_concurrent * 0.4) + (a.avg_concurrent * 0.4) + (COALESCE(g.growth_rate,0) * 100 * 0.2) AS trending_score
+        FROM peak p
+                 JOIN avg_play a ON p.game_id = a.game_id
+                 LEFT JOIN growth g ON p.game_id = g.game_id
+        ORDER BY trending_score DESC
+        LIMIT 50;
+END;
+$$;
+
+
+CREATE OR REPLACE FUNCTION proc_daily_trending()
+    RETURNS TABLE(
+                     game_id BIGINT,
+                     peak_concurrent BIGINT,
+                     avg_concurrent NUMERIC(12,2),
+                     growth_rate NUMERIC(6,2),
+                     trending_score NUMERIC(12,2)
+                 )
+    LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN QUERY
+        WITH peak AS (
+            SELECT game_id, MAX(count) AS peak_concurrent
+            FROM playing_count_record
+            WHERE record_at >= EXTRACT(EPOCH FROM (NOW() - INTERVAL '1 days')) * 1000
+            GROUP BY game_id
+        ),
+             avg_play AS (
+                 SELECT game_id, AVG(count) AS avg_concurrent
+                 FROM playing_count_record
+                 WHERE record_at >= EXTRACT(EPOCH FROM (NOW() - INTERVAL '1 days')) * 1000
+                 GROUP BY game_id
+             ),
+             growth AS (
+                 SELECT t.game_id,
+                        CASE
+                            WHEN l.avg_last > 0 THEN (t.avg_this - l.avg_last) / l.avg_last
+                            ELSE 1
+                            END AS growth_rate
+                 FROM (
+                          SELECT game_id, AVG(count) AS avg_this
+                          FROM playing_count_record
+                          WHERE record_at >= EXTRACT(EPOCH FROM (NOW() - INTERVAL '1 days')) * 1000
+                          GROUP BY game_id
+                      ) t
+                          LEFT JOIN (
+                     SELECT game_id, AVG(count) AS avg_last
+                     FROM playing_count_record
+                     WHERE record_at >= EXTRACT(EPOCH FROM (NOW() - INTERVAL '2 days')) * 1000
+                       AND record_at < EXTRACT(EPOCH FROM (NOW() - INTERVAL '1 days')) * 1000
+                     GROUP BY game_id
+                 ) l ON t.game_id = l.game_id
+             )
+        SELECT p.game_id,
+               p.peak_concurrent,
+               a.avg_concurrent,
+               g.growth_rate,
+               (p.peak_concurrent * 0.4) + (a.avg_concurrent * 0.4) + (COALESCE(g.growth_rate,0) * 100 * 0.2) AS trending_score
+        FROM peak p
+                 JOIN avg_play a ON p.game_id = a.game_id
+                 LEFT JOIN growth g ON p.game_id = g.game_id
+        ORDER BY trending_score DESC
+        LIMIT 50;
+END;
+$$;

--- a/migrations/20250817112238_add-trending-record-table.sql
+++ b/migrations/20250817112238_add-trending-record-table.sql
@@ -1,0 +1,17 @@
+-- Create "top_50_monthly_trending" table
+CREATE TABLE "public"."top_50_monthly_trending" (
+  "year" integer NOT NULL,
+  "month" integer NOT NULL,
+  "rank" integer NOT NULL,
+  "game_id" bigint NOT NULL,
+  "peak_concurrent" bigint NOT NULL,
+  "avg_concurrent" numeric(12,2) NOT NULL,
+  "growth_rate" numeric(6,2) NOT NULL,
+  "trending_score" numeric(12,2) NOT NULL,
+  PRIMARY KEY ("year", "month", "rank"),
+  CONSTRAINT "top_50_monthly_trending_game_id_fkey" FOREIGN KEY ("game_id") REFERENCES "public"."game" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION
+);
+-- Create index "idx_top_50_monthly_trending_game_id" to table: "top_50_monthly_trending"
+CREATE INDEX "idx_top_50_monthly_trending_game_id" ON "public"."top_50_monthly_trending" ("game_id");
+-- Create index "idx_top_50_monthly_trending_year_month" to table: "top_50_monthly_trending"
+CREATE INDEX "idx_top_50_monthly_trending_year_month" ON "public"."top_50_monthly_trending" ("year", "month");

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:Dib96pksGijoNq2Ex0MV+bjd8mhGT3nifcbluarfQiA=
+h1:j1wcDUJN9o878//LucpYuH6UCtlEBVgjfnomdqNPuKw=
 20250706170756_migrate-datetime-to-bigint.sql h1:5JrcN/MgdPa3aItd1d1933e6qfnTW8l6qRWiXP76nQQ=
 20250706170919_add-game-default-created-at.sql h1:8EqGnGq3gsxGa0YGT0c1Q9yxTXsUglQe9fSKYUP96Bo=
 20250706170931.sql h1:VdBUOWMkg+Ua82QGrSeIZ2luY6+z7Wr0LHjCTE1A5So=
@@ -15,3 +15,5 @@ h1:Dib96pksGijoNq2Ex0MV+bjd8mhGT3nifcbluarfQiA=
 20250805131240_add-playing-count-record.sql h1:Gx2IvP7717yGEW1u93MrzVP0IABWT/zboHiDVbtucQ4=
 20250805132513_re-index-playing-count-record.sql h1:T5GEej3tVTZQ67I1FkRLs115eNkxUc9UfY2t0+YuRJ4=
 20250805151311_modify-playing-count-record.sql h1:CQV5shahJOpt5afaJFTP9OyCkx2UptaQ7XUP7ODKNCQ=
+20250817105908_trending-procedure.sql h1:qM5ICd0P7t/P7SGwTzTDzYRO3nmMi+XLDZZvs+6DcxI=
+20250817112238_add-trending-record-table.sql h1:d7XqPZ7MlOEZ6FlJMtj1LXty2Grel83RBvFh2GGrj0I=

--- a/schema.pg.hcl
+++ b/schema.pg.hcl
@@ -1292,6 +1292,56 @@ table "playing_count_record" {
     columns = [column.game_id]
   }
   index "idx_playing_count_record_record_at" {
-    columns = [column.game_id,column.record_at]
+    columns = [column.game_id, column.record_at]
+  }
+}
+table "top_50_monthly_trending" {
+  schema = schema.public
+  column "year" {
+    null = false
+    type = integer
+  }
+  column "month" {
+    null = false
+    type = integer
+  }
+  column "rank" {
+    null = false
+    type = integer
+  }
+  column "game_id" {
+    null = false
+    type = bigint
+  }
+  column "peak_concurrent" {
+    null = false
+    type = bigint
+  }
+  column "avg_concurrent" {
+    null = false
+    type = numeric(12, 2)
+  }
+  column "growth_rate" {
+    null = false
+    type = numeric(6, 2)
+  }
+  column "trending_score" {
+    null = false
+    type = numeric(12, 2)
+  }
+  primary_key {
+    columns = [column.year, column.month, column.rank]
+  }
+  foreign_key "top_50_monthly_trending_game_id_fkey" {
+    columns     = [column.game_id]
+    ref_columns = [table.game.column.id]
+    on_update   = NO_ACTION
+    on_delete   = NO_ACTION
+  }
+  index "idx_top_50_monthly_trending_game_id" {
+    columns = [column.game_id]
+  }
+  index "idx_top_50_monthly_trending_year_month" {
+    columns = [column.year, column.month]
   }
 }

--- a/src/main/java/com/bravos/steak/store/controller/GameStoreController.java
+++ b/src/main/java/com/bravos/steak/store/controller/GameStoreController.java
@@ -2,7 +2,6 @@ package com.bravos.steak.store.controller;
 
 import com.bravos.steak.store.model.request.FilterQuery;
 import com.bravos.steak.store.service.GameService;
-import jakarta.validation.Valid;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
@@ -27,8 +26,8 @@ public class GameStoreController {
         return ResponseEntity.ok(gameService.getGameStoreList(cursor.orElse(null), pageSize));
     }
 
-    @GetMapping("/filter")
-    public ResponseEntity<?> getGameListStoreWithFilters(@RequestBody @Valid FilterQuery filterQuery) {
+    @PostMapping("/filter")
+    public ResponseEntity<?> getGameListStoreWithFilters(@RequestBody(required = false) FilterQuery filterQuery) {
         return ResponseEntity.ok(gameService.getFilteredGames(filterQuery));
     }
 

--- a/src/main/java/com/bravos/steak/store/cronjob/TrendingTrackingJob.java
+++ b/src/main/java/com/bravos/steak/store/cronjob/TrendingTrackingJob.java
@@ -1,0 +1,24 @@
+package com.bravos.steak.store.cronjob;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TrendingTrackingJob {
+
+    @Scheduled(cron = "0 0 1 * * Mon")
+    public void updateWeeklyTrending() {
+
+    }
+
+    @Scheduled(cron = "0 0 1 1 * ?")
+    public void updateMonthlyTrending() {
+
+    }
+
+    @Scheduled(cron = "0 0 1 * * *")
+    public void updateDailyTrending() {
+
+    }
+
+}

--- a/src/main/java/com/bravos/steak/store/model/request/FilterQuery.java
+++ b/src/main/java/com/bravos/steak/store/model/request/FilterQuery.java
@@ -1,6 +1,5 @@
 package com.bravos.steak.store.model.request;
 
-import jakarta.validation.constraints.Min;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
 
@@ -28,12 +27,8 @@ public class FilterQuery {
 
     String sortBy;
 
-    @Min(1)
-    @Builder.Default
     Integer page = 1;
 
-    @Min(1)
-    @Builder.Default
     Integer pageSize = 10;
 
     @Override

--- a/src/main/java/com/bravos/steak/store/service/impl/GameServiceImpl.java
+++ b/src/main/java/com/bravos/steak/store/service/impl/GameServiceImpl.java
@@ -76,6 +76,9 @@ public class GameServiceImpl implements GameService {
 
     @Override
     public CustomPage<GameListItem> getFilteredGames(FilterQuery filterQuery) {
+        if(filterQuery == null) {
+            return getNewestGames(1,15);
+        }
         if(filterQuery.getMinPrice() != null && filterQuery.getMaxPrice() != null
                 && filterQuery.getMinPrice() > filterQuery.getMaxPrice()) {
             double temp = filterQuery.getMinPrice();


### PR DESCRIPTION
This pull request introduces trending tracking functionality to the game store, including new SQL procedures for calculating trending games, a new table for storing monthly trending records, and backend changes to support filtering and sorting games by new criteria. The most significant changes are grouped below by database and backend logic improvements.

**Database: Trending Calculation & Storage**

* Added three SQL procedures (`proc_weekly_trending`, `proc_monthly_trending`, `proc_daily_trending`) to compute trending games based on peak concurrent users, average concurrent users, and growth rate over daily, weekly, and monthly periods. These procedures return the top 50 trending games for each period.
* Added a new table `top_50_monthly_trending` to store the top 50 monthly trending games, including fields for year, month, rank, game stats, and trending score, with appropriate indexes and foreign key constraints. [[1]](diffhunk://#diff-e2010c80616e05e0c78a6a190e7884018b9338bce229f821ff1db872b7db995eR1-R17) [[2]](diffhunk://#diff-c069c30294b8e0404a369d48975208cb3a2f8c2ce93f3c66fa22ce829b2eab83R1298-R1347)
* Updated migration tracking files to include the new trending procedures and table. [[1]](diffhunk://#diff-d1a0068eb30a1031550958abf8884b852621503fce81fce7666740bc9530e44cL1-R1) [[2]](diffhunk://#diff-d1a0068eb30a1031550958abf8884b852621503fce81fce7666740bc9530e44cR18-R19)

**Backend: Trending Cronjobs & Filtering Improvements**

* Introduced a new `TrendingTrackingJob` cronjob class with scheduled methods for updating weekly, monthly, and daily trending records (skeletons for future implementation).
* Enhanced game filtering: the `/filter` endpoint now accepts POST requests and allows for null filter queries, defaulting to the newest games if no filters are provided. Validation annotations were removed from `FilterQuery`, and backend logic was updated to handle missing or invalid price ranges gracefully. [[1]](diffhunk://#diff-6bdbe57a059babeab3b79fa6094e7a452c8df427e37630f7a50aac670896f4d4L30-R30) [[2]](diffhunk://#diff-bd8c22b3b4cffae0f28868d2980cfe2a76387f590efc363330e7af13816799d8L31-L36) [[3]](diffhunk://#diff-b17785a644713ca19ae629c631f521b11347088679bbde03d7c6f7ca56bee360R79-R81)

**Backend: Sorting and Specification Enhancements**

* Improved game sorting in filters: added support for sorting by `releaseDate`, `name`, and `buyerCount` (number of buyers), with robust validation and error handling for invalid sort fields. Sorting by `buyerCount` uses a subquery for accurate ordering. [[1]](diffhunk://#diff-386b945ba07f8e9c033beb501de8b10316d1ee39fae9522a5c600bdf4bdccf85L17-R19) [[2]](diffhunk://#diff-386b945ba07f8e9c033beb501de8b10316d1ee39fae9522a5c600bdf4bdccf85L70-L84)
* Ensured only games with status `OPENING` and released before the current time are included in filtered results.

These changes lay the groundwork for tracking and displaying trending games, as well as improving the flexibility and robustness of game filtering and sorting in the store.