### PR TITLE
add-ranking-checking

### DIFF
--- a/migrations/20250820192021_update-trending-proc.sql
+++ b/migrations/20250820192021_update-trending-proc.sql
@@ -1,0 +1,187 @@
+CREATE OR REPLACE FUNCTION proc_weekly_trending(as_of_time TIMESTAMP DEFAULT NOW())
+    RETURNS TABLE(
+                     game_id BIGINT,
+                     peak_concurrent BIGINT,
+                     avg_concurrent NUMERIC(12,2),
+                     growth_rate NUMERIC(6,2),
+                     trending_score NUMERIC(12,2)
+                 )
+    LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN QUERY
+        WITH peak AS (
+            SELECT game_id, MAX(count) AS peak_concurrent
+            FROM playing_count_record
+            WHERE record_at >= EXTRACT(EPOCH FROM (as_of_time - INTERVAL '7 days')) * 1000
+              AND record_at < EXTRACT(EPOCH FROM as_of_time) * 1000
+            GROUP BY game_id
+        ),
+             avg_play AS (
+                 SELECT game_id, AVG(count) AS avg_concurrent
+                 FROM playing_count_record
+                 WHERE record_at >= EXTRACT(EPOCH FROM (as_of_time - INTERVAL '7 days')) * 1000
+                   AND record_at < EXTRACT(EPOCH FROM as_of_time) * 1000
+                 GROUP BY game_id
+             ),
+             growth AS (
+                 SELECT t.game_id,
+                        CASE
+                            WHEN l.avg_last > 0 THEN (t.avg_this - l.avg_last) / l.avg_last
+                            ELSE 1
+                            END AS growth_rate
+                 FROM (
+                          SELECT game_id, AVG(count) AS avg_this
+                          FROM playing_count_record
+                          WHERE record_at >= EXTRACT(EPOCH FROM (as_of_time - INTERVAL '7 days')) * 1000
+                            AND record_at < EXTRACT(EPOCH FROM as_of_time) * 1000
+                          GROUP BY game_id
+                      ) t
+                          LEFT JOIN (
+                     SELECT game_id, AVG(count) AS avg_last
+                     FROM playing_count_record
+                     WHERE record_at >= EXTRACT(EPOCH FROM (as_of_time - INTERVAL '14 days')) * 1000
+                       AND record_at < EXTRACT(EPOCH FROM (as_of_time - INTERVAL '7 days')) * 1000
+                     GROUP BY game_id
+                 ) l ON t.game_id = l.game_id
+             )
+        SELECT p.game_id,
+               p.peak_concurrent,
+               a.avg_concurrent,
+               g.growth_rate,
+               (p.peak_concurrent * 0.4) + (a.avg_concurrent * 0.4) + (COALESCE(g.growth_rate,0) * 100 * 0.2) AS trending_score
+        FROM peak p
+                 JOIN avg_play a ON p.game_id = a.game_id
+                 LEFT JOIN growth g ON p.game_id = g.game_id
+                 JOIN game ON p.game_id = game.id
+        WHERE game.status = 0
+        ORDER BY trending_score DESC
+        LIMIT 50;
+END;
+$$;
+
+
+CREATE OR REPLACE FUNCTION proc_monthly_trending(as_of_time TIMESTAMP DEFAULT NOW())
+    RETURNS TABLE(
+                     game_id BIGINT,
+                     peak_concurrent BIGINT,
+                     avg_concurrent NUMERIC(12,2),
+                     growth_rate NUMERIC(6,2),
+                     trending_score NUMERIC(12,2)
+                 )
+    LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN QUERY
+        WITH peak AS (
+            SELECT game_id, MAX(count) AS peak_concurrent
+            FROM playing_count_record
+            WHERE record_at >= EXTRACT(EPOCH FROM (as_of_time - INTERVAL '30 days')) * 1000
+              AND record_at < EXTRACT(EPOCH FROM as_of_time) * 1000
+            GROUP BY game_id
+        ),
+             avg_play AS (
+                 SELECT game_id, AVG(count) AS avg_concurrent
+                 FROM playing_count_record
+                 WHERE record_at >= EXTRACT(EPOCH FROM (as_of_time - INTERVAL '30 days')) * 1000
+                   AND record_at < EXTRACT(EPOCH FROM as_of_time) * 1000
+                 GROUP BY game_id
+             ),
+             growth AS (
+                 SELECT t.game_id,
+                        CASE
+                            WHEN l.avg_last > 0 THEN (t.avg_this - l.avg_last) / l.avg_last
+                            ELSE 1
+                            END AS growth_rate
+                 FROM (
+                          SELECT game_id, AVG(count) AS avg_this
+                          FROM playing_count_record
+                          WHERE record_at >= EXTRACT(EPOCH FROM (as_of_time - INTERVAL '30 days')) * 1000
+                            AND record_at < EXTRACT(EPOCH FROM as_of_time) * 1000
+                          GROUP BY game_id
+                      ) t
+                          LEFT JOIN (
+                     SELECT game_id, AVG(count) AS avg_last
+                     FROM playing_count_record
+                     WHERE record_at >= EXTRACT(EPOCH FROM (as_of_time - INTERVAL '60 days')) * 1000
+                       AND record_at < EXTRACT(EPOCH FROM (as_of_time - INTERVAL '30 days')) * 1000
+                     GROUP BY game_id
+                 ) l ON t.game_id = l.game_id
+             )
+        SELECT p.game_id,
+               p.peak_concurrent,
+               a.avg_concurrent,
+               g.growth_rate,
+               (p.peak_concurrent * 0.4) + (a.avg_concurrent * 0.4) + (COALESCE(g.growth_rate,0) * 100 * 0.2) AS trending_score
+        FROM peak p
+                 JOIN avg_play a ON p.game_id = a.game_id
+                 LEFT JOIN growth g ON p.game_id = g.game_id
+                 JOIN game ON p.game_id = game.id
+        WHERE game.status = 0
+        ORDER BY trending_score DESC
+        LIMIT 50;
+END;
+$$;
+
+
+CREATE OR REPLACE FUNCTION proc_daily_trending(as_of_time TIMESTAMP DEFAULT NOW())
+    RETURNS TABLE(
+                     game_id BIGINT,
+                     peak_concurrent BIGINT,
+                     avg_concurrent NUMERIC(12,2),
+                     growth_rate NUMERIC(6,2),
+                     trending_score NUMERIC(12,2)
+                 )
+    LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN QUERY
+        WITH peak AS (
+            SELECT game_id, MAX(count) AS peak_concurrent
+            FROM playing_count_record
+            WHERE record_at >= EXTRACT(EPOCH FROM (as_of_time - INTERVAL '1 days')) * 1000
+              AND record_at < EXTRACT(EPOCH FROM as_of_time) * 1000
+            GROUP BY game_id
+        ),
+             avg_play AS (
+                 SELECT game_id, AVG(count) AS avg_concurrent
+                 FROM playing_count_record
+                 WHERE record_at >= EXTRACT(EPOCH FROM (as_of_time - INTERVAL '1 days')) * 1000
+                   AND record_at < EXTRACT(EPOCH FROM as_of_time) * 1000
+                 GROUP BY game_id
+             ),
+             growth AS (
+                 SELECT t.game_id,
+                        CASE
+                            WHEN l.avg_last > 0 THEN (t.avg_this - l.avg_last) / l.avg_last
+                            ELSE 1
+                            END AS growth_rate
+                 FROM (
+                          SELECT game_id, AVG(count) AS avg_this
+                          FROM playing_count_record
+                          WHERE record_at >= EXTRACT(EPOCH FROM (as_of_time - INTERVAL '1 days')) * 1000
+                            AND record_at < EXTRACT(EPOCH FROM as_of_time) * 1000
+                          GROUP BY game_id
+                      ) t
+                          LEFT JOIN (
+                     SELECT game_id, AVG(count) AS avg_last
+                     FROM playing_count_record
+                     WHERE record_at >= EXTRACT(EPOCH FROM (as_of_time - INTERVAL '2 days')) * 1000
+                       AND record_at < EXTRACT(EPOCH FROM (as_of_time - INTERVAL '1 days')) * 1000
+                     GROUP BY game_id
+                 ) l ON t.game_id = l.game_id
+             )
+        SELECT p.game_id,
+               p.peak_concurrent,
+               a.avg_concurrent,
+               g.growth_rate,
+               (p.peak_concurrent * 0.4) + (a.avg_concurrent * 0.4) + (COALESCE(g.growth_rate,0) * 100 * 0.2) AS trending_score
+        FROM peak p
+                 JOIN avg_play a ON p.game_id = a.game_id
+                 LEFT JOIN growth g ON p.game_id = g.game_id
+                 JOIN game ON p.game_id = game.id
+        WHERE game.status = 0
+        ORDER BY trending_score DESC
+        LIMIT 50;
+END;
+$$;

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:mkBJy9w4/QlLE/ZjezhWGv2zIe47ZpyZn9mdTuA2Su0=
+h1:KW3cF1078MEiBCtzmJLqbXUX13J/37B4V3+yvmTcH8M=
 20250706170756_migrate-datetime-to-bigint.sql h1:5JrcN/MgdPa3aItd1d1933e6qfnTW8l6qRWiXP76nQQ=
 20250706170919_add-game-default-created-at.sql h1:8EqGnGq3gsxGa0YGT0c1Q9yxTXsUglQe9fSKYUP96Bo=
 20250706170931.sql h1:VdBUOWMkg+Ua82QGrSeIZ2luY6+z7Wr0LHjCTE1A5So=
@@ -17,3 +17,4 @@ h1:mkBJy9w4/QlLE/ZjezhWGv2zIe47ZpyZn9mdTuA2Su0=
 20250805151311_modify-playing-count-record.sql h1:CQV5shahJOpt5afaJFTP9OyCkx2UptaQ7XUP7ODKNCQ=
 20250817105908_trending-procedure.sql h1:+CuBwpAM250J1GSuvThwEEZvMnDzVIVxM4XGwuJudss=
 20250817112238_add-trending-record-table.sql h1:g8DT998GUu+W5F5/rg5muyXm+bL3fuER4tvmaZ+bzUg=
+20250820192021_update-trending-proc.sql h1:5I572Sbb7fu+/kbWuFmVJiaPmtfOwJcFOgjTBY1zVFo=

--- a/src/main/java/com/bravos/steak/store/repo/GameRepository.java
+++ b/src/main/java/com/bravos/steak/store/repo/GameRepository.java
@@ -5,11 +5,9 @@ import com.bravos.steak.store.entity.Game;
 import com.bravos.steak.store.model.enums.GameStatus;
 import com.bravos.steak.store.repo.injection.GameIdStatusPrice;
 import com.bravos.steak.store.repo.injection.GamePrice;
-import com.bravos.steak.store.repo.injection.TrendingStatistic;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.*;
-import org.springframework.data.jpa.repository.query.Procedure;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -84,13 +82,6 @@ public interface GameRepository extends JpaRepository<Game, Long>, JpaSpecificat
 
     Game findByIdAndPublisherId(Long id, Long publisherId);
 
-    @Procedure(procedureName = "proc_weekly_trending")
-    List<TrendingStatistic> getWeeklyTrendingStatistics();
 
-    @Procedure(procedureName = "proc_monthly_trending")
-    List<TrendingStatistic> getMonthlyTrendingStatistics();
-
-    @Procedure(procedureName = "proc_daily_trending")
-    List<TrendingStatistic> getDailyTrendingStatistics();
 
 }

--- a/src/main/java/com/bravos/steak/store/repo/TopMonthlyGameRepository.java
+++ b/src/main/java/com/bravos/steak/store/repo/TopMonthlyGameRepository.java
@@ -2,9 +2,13 @@ package com.bravos.steak.store.repo;
 
 import com.bravos.steak.store.entity.Top50MonthlyTrendingRecord;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface TopMonthlyGameRepository extends JpaRepository<Top50MonthlyTrendingRecord, Long> {
+
+    @Query("SELECT COUNT(*) > 0 FROM Top50MonthlyTrendingRecord WHERE id.month = ?1 AND id.year = ?2")
+    boolean existsByTime(int currentMonth, int currentYear);
 
 }

--- a/src/main/java/com/bravos/steak/store/repo/TrendingStatisticRepository.java
+++ b/src/main/java/com/bravos/steak/store/repo/TrendingStatisticRepository.java
@@ -1,0 +1,68 @@
+package com.bravos.steak.store.repo;
+
+import com.bravos.steak.store.repo.injection.TrendingStatistic;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Query;
+import org.springframework.stereotype.Repository;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+@Repository
+public class TrendingStatisticRepository {
+
+    private final ObjectMapper objectMapper;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    public TrendingStatisticRepository(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public List<TrendingStatistic> getWeeklyTrendingStatistics() {
+        LocalDateTime startOfWeek = LocalDateTime.now()
+                .with(DayOfWeek.MONDAY)
+                .withHour(0)
+                .withMinute(0)
+                .withSecond(0)
+                .atZone(ZoneId.of("GMT+7"))
+                .toLocalDateTime();
+        String sql = "SELECT * FROM proc_weekly_trending(?)";
+        return queryTrendingStatistics(sql, startOfWeek);
+    }
+
+    public List<TrendingStatistic> getMonthlyTrendingStatistics() {
+        LocalDateTime startOfMonth = LocalDateTime.now()
+                .withDayOfMonth(1)
+                .withHour(0)
+                .withMinute(0)
+                .withSecond(0)
+                .atZone(ZoneId.of("GMT+7"))
+                .toLocalDateTime();
+        String sql = "SELECT * FROM proc_monthly_trending(?)";
+        return queryTrendingStatistics(sql, startOfMonth);
+    }
+
+    public List<TrendingStatistic> getDailyTrendingStatistics() {
+        LocalDateTime asTime = LocalDateTime.now()
+                .toLocalDate()
+                .atStartOfDay()
+                .atZone(ZoneId.of("GMT+7"))
+                .toLocalDateTime();
+        String sql = "SELECT * FROM proc_daily_trending(?)";
+        return queryTrendingStatistics(sql, asTime);
+    }
+
+    private List<TrendingStatistic> queryTrendingStatistics(String sql, LocalDateTime asTime) {
+        Query query = entityManager.createNativeQuery(sql, "TrendingStatisticMapping");
+        query.setParameter(0, asTime);
+        return objectMapper.convertValue(query.getResultList(),
+                objectMapper.getTypeFactory().constructCollectionType(List.class, TrendingStatistic.class));
+    }
+
+}

--- a/src/main/java/com/bravos/steak/store/repo/injection/TrendingStatistic.java
+++ b/src/main/java/com/bravos/steak/store/repo/injection/TrendingStatistic.java
@@ -1,5 +1,8 @@
 package com.bravos.steak.store.repo.injection;
 
+import jakarta.persistence.ColumnResult;
+import jakarta.persistence.ConstructorResult;
+import jakarta.persistence.SqlResultSetMapping;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
 
@@ -11,6 +14,19 @@ import static lombok.AccessLevel.PRIVATE;
 @AllArgsConstructor
 @Builder
 @FieldDefaults(level = PRIVATE)
+@SqlResultSetMapping(
+        name = "TrendingStatisticMapping",
+        classes = @ConstructorResult(
+                targetClass = TrendingStatistic.class,
+                columns = {
+                        @ColumnResult(name = "gameId", type = Long.class),
+                        @ColumnResult(name = "peakConcurrent", type = Long.class),
+                        @ColumnResult(name = "avgConcurrent", type = Double.class),
+                        @ColumnResult(name = "growthRate", type = Double.class),
+                        @ColumnResult(name = "trendingScore", type = Double.class)
+                }
+        )
+)
 public class TrendingStatistic {
 
     Long gameId;

--- a/src/main/java/com/bravos/steak/store/service/GameService.java
+++ b/src/main/java/com/bravos/steak/store/service/GameService.java
@@ -38,10 +38,10 @@ public interface GameService {
 
     List<TrendingStatistic> getDailyTrendingStatistics();
 
-    List<GameRankingListItem> getCurrentDayGameRankingList(int page, int pageSize);
+    List<GameRankingListItem> getCurrentDayGameRankingList();
 
-    List<GameRankingListItem> getCurrentWeekGameRankingList(int page, int pageSize);
+    List<GameRankingListItem> getCurrentWeekGameRankingList();
 
-    List<GameRankingListItem> getCurrentMonthGameRankingList(int page, int pageSize);
+    List<GameRankingListItem> getCurrentMonthGameRankingList();
 
 }


### PR DESCRIPTION
This pull request refactors how trending statistics are calculated and retrieved for games, moving the logic from the `GameRepository` to a dedicated `TrendingStatisticRepository`. It also updates the scheduled job to use the new repository and trending procedures, introduces improved error handling, and updates the trending SQL procedures for daily, weekly, and monthly statistics. Additionally, it makes minor improvements to repository queries and service interfaces.

**Trending statistics calculation and retrieval:**

* Added a new `TrendingStatisticRepository` to handle trending statistics queries, moving the logic out of `GameRepository` and using native SQL calls to the updated procedures.
* Removed trending statistics procedures from `GameRepository`, centralizing the logic in the new repository. [[1]](diffhunk://#diff-163725e1b6298d3c9c9723e04c3a56313c892b0bbb9bc8e449c4cad39915e461L8-L12) [[2]](diffhunk://#diff-163725e1b6298d3c9c9723e04c3a56313c892b0bbb9bc8e449c4cad39915e461L87-L94)

**Trending SQL procedures update:**

* Added new SQL procedures in `migrations/20250820192021_update-trending-proc.sql` for daily, weekly, and monthly trending calculations, improving the calculation of peak, average, growth rate, and trending score.

**Scheduled job and error handling improvements:**

* Refactored `TrendingTrackingJob` to use `TrendingStatisticRepository`, updated cron schedules to use GMT+7, added transactional annotation and improved error handling for monthly trending updates. [[1]](diffhunk://#diff-925d4e394b8710219ffce2c28e523830601b2b40fc03c3ab796797552c5b7865L7-R10) [[2]](diffhunk://#diff-925d4e394b8710219ffce2c28e523830601b2b40fc03c3ab796797552c5b7865L23-R50) [[3]](diffhunk://#diff-925d4e394b8710219ffce2c28e523830601b2b40fc03c3ab796797552c5b7865L67-R80)

**Repository and entity mapping enhancements:**

* Added a `@SqlResultSetMapping` to `TrendingStatistic` for mapping native query results, and implemented an existence check in `TopMonthlyGameRepository` for monthly trending records. [[1]](diffhunk://#diff-d63605ffd9a4d5384cabe859cad38818caba34e20b744947d0d3365bb20aad1fR3-R5) [[2]](diffhunk://#diff-d63605ffd9a4d5384cabe859cad38818caba34e20b744947d0d3365bb20aad1fR17-R29) [[3]](diffhunk://#diff-d2605db48bb0476a8f9926c9dcdd7607b755d707194ee97c1f026947d034d2f4R5-R13)

**Service interface update:**

* Simplified the trending ranking list methods in `GameService` to remove pagination parameters, making the interface cleaner.

Let me know if you want to walk through any specific part of the refactor or the new trending calculation logic!