### PR TITLE
fix-admin-statistic

### DIFF
--- a/src/main/java/com/bravos/steak/administration/controller/AdminStatisticController.java
+++ b/src/main/java/com/bravos/steak/administration/controller/AdminStatisticController.java
@@ -30,7 +30,7 @@ public class AdminStatisticController {
     }
 
     @GetMapping("/monthly-revenue")
-    public ResponseEntity<?> getRevenueStatisticByMonth(@RequestParam(value = "year") Integer year) {
+    public ResponseEntity<?> getRevenueStatisticByMonth(@RequestParam Integer year) {
         if (year == null || year < 2000 || year > 2100) {
             year = LocalDate.now().getYear();
         }
@@ -39,8 +39,8 @@ public class AdminStatisticController {
 
     @GetMapping("/daily-revenue")
     public ResponseEntity<?> getRevenueStatisticByDay(
-            @RequestParam(value = "month") Integer month,
-            @RequestParam(value = "year") Integer year) {
+            @RequestParam Integer month,
+            @RequestParam Integer year) {
         if (month == null || month < 1 || month > 12) {
             month = LocalDate.now().getMonthValue();
         }


### PR DESCRIPTION
This pull request makes minor improvements to the request parameter annotations in the `AdminStatisticController` to simplify endpoint definitions.

* Controller endpoint improvements:
  * Changed the `@RequestParam` annotations for `year` and `month` parameters in `getRevenueStatisticByMonth` and `getRevenueStatisticByDay` methods to use the default format without specifying the `value` attribute, resulting in cleaner and more concise code. (`src/main/java/com/bravos/steak/administration/controller/AdminStatisticController.java`) [[1]](diffhunk://#diff-2ebecce6bc7bb9f97d849fdddd2c9e61bdf390ae83f325d00d6e137499d440b3L33-R33) [[2]](diffhunk://#diff-2ebecce6bc7bb9f97d849fdddd2c9e61bdf390ae83f325d00d6e137499d440b3L42-R43)