### PR TITLE
fix-minor-bugs

### DIFF
--- a/src/main/java/com/bravos/steak/administration/repo/AdminStatisticRepository.java
+++ b/src/main/java/com/bravos/steak/administration/repo/AdminStatisticRepository.java
@@ -42,7 +42,7 @@ public class AdminStatisticRepository {
         for (Object obj : result) {
             Object[] arr = (Object[]) obj;
             StatisticResponse statisticResponse = StatisticResponse.builder()
-                    .name((String) arr[0])
+                    .name(String.valueOf(arr[0]))
                     .value(arr[1])
                     .build();
             res.add(statisticResponse);


### PR DESCRIPTION
This pull request includes a minor update to the `buildResultMap` method in `AdminStatisticRepository.java` to improve type safety and reliability when setting the `name` field in the `StatisticResponse` object.

* Changed the assignment of the `name` field in the `StatisticResponse` builder to use `String.valueOf(arr[0])` instead of a direct cast, ensuring that the value is safely converted to a string regardless of its original type.