### PR TITLE
optimize-server

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,13 @@ server:
     enabled: true
     mime-types: application/json,application/xml,text/html,text/xml,text/plain
     min-response-size: 2048
+  tomcat:
+    threads:
+      max: 500
+      min-spare: 50
+    accept-count: 2000
+    max-connections: 12000
+    connection-timeout: 20000
 spring:
   application:
     name: steak-platform


### PR DESCRIPTION
This pull request updates the Tomcat server configuration in `application.yml` to improve connection handling and scalability. The most important changes are grouped below:

Tomcat thread and connection settings:

* Increased the maximum number of Tomcat threads to 500 and set the minimum spare threads to 50, allowing for better concurrency and resource management.
* Raised the accept count to 2000 and the maximum number of connections to 12,000, supporting higher traffic loads.
* Set the Tomcat connection timeout to 20,000 milliseconds to control how long the server waits for connections.