### PR TITLE
change-seed-logic

### DIFF
--- a/src/main/java/com/bravos/steak/common/seed/Generator.java
+++ b/src/main/java/com/bravos/steak/common/seed/Generator.java
@@ -219,7 +219,7 @@ public class Generator {
         log.info("Generating order data for user {} with {} games", userId, randomGameIds.size());
 
         int startMonth = startTime.getMonthValue();
-        int endMonth = endTime != null ? endTime.getMonth().getValue() - 1 : 12;
+        int endMonth = endTime != null ? endTime.getMonth().getValue() : 12;
         while (!randomGameIds.isEmpty() && startMonth <= endMonth) {
             int randomQuantity = Math.min(RANDOM.nextInt(1, 4), randomGameIds.size());
             Set<Long> randomGameIdsForOrder = new HashSet<>(randomQuantity);


### PR DESCRIPTION
This pull request makes a small fix to the calculation of the `endMonth` variable in the `generateOrderData` method. The change ensures that the month value for `endMonth` is not decremented by one, which aligns the logic with the expected behavior when generating order data.

([src/main/java/com/bravos/steak/common/seed/Generator.javaL222-R222](diffhunk://#diff-c9250bff1d2655c8510957d40e1e220e2e7162652fa0ea837d8e52d0e0d19b55L222-R222))