### PR TITLE
fix-order-bug

### DIFF
--- a/src/main/java/com/bravos/steak/common/seed/Generator.java
+++ b/src/main/java/com/bravos/steak/common/seed/Generator.java
@@ -4,9 +4,7 @@ import com.bravos.steak.common.service.helper.DateTimeHelper;
 import com.bravos.steak.common.service.snowflake.SnowflakeGenerator;
 import com.bravos.steak.store.entity.*;
 import com.bravos.steak.store.model.enums.OrderStatus;
-import com.bravos.steak.store.repo.GameRepository;
-import com.bravos.steak.store.repo.OrderRepository;
-import com.bravos.steak.store.repo.UserGameRepository;
+import com.bravos.steak.store.repo.*;
 import com.bravos.steak.useraccount.entity.UserAccount;
 import com.bravos.steak.useraccount.entity.UserProfile;
 import com.bravos.steak.useraccount.model.enums.AccountStatus;
@@ -49,16 +47,20 @@ public class Generator {
     private final UserProfileRepository userProfileRepository;
     private final GameRepository gameRepository;
     private final UserGameRepository userGameRepository;
+    private final TrendingStatisticRepository trendingStatisticRepository;
+    private final PlayingCountRecordRepository playingCountRecordRepository;
 
     public Generator(SnowflakeGenerator snowflakeGenerator, UserAccountRepository userAccountRepository,
                      UserProfileRepository userProfileRepository, GameRepository gameRepository,
-                     OrderRepository orderRepository, UserGameRepository userGameRepository) {
+                     OrderRepository orderRepository, UserGameRepository userGameRepository, TrendingStatisticRepository trendingStatisticRepository, PlayingCountRecordRepository playingCountRecordRepository) {
         this.snowflakeGenerator = snowflakeGenerator;
         this.userAccountRepository = userAccountRepository;
         this.userProfileRepository = userProfileRepository;
         this.gameRepository = gameRepository;
         this.orderRepository = orderRepository;
         this.userGameRepository = userGameRepository;
+        this.trendingStatisticRepository = trendingStatisticRepository;
+        this.playingCountRecordRepository = playingCountRecordRepository;
     }
 
     private String generateRandomUsername() {
@@ -271,6 +273,17 @@ public class Generator {
         log.info("Generated {} orders for user {}", orders.size(), userId);
 
         return new OrderUserGamePair(orders, userGames);
+    }
+
+    @Scheduled(cron = "0 0 3 * * *")
+    public void generateGameLeaderboard() {
+        log.info("Generating game leaderboard data...");
+        List<PlayingCountRecord> records = playingCountRecordRepository.findAll();
+        for (PlayingCountRecord record : records) {
+            record.setCount((long) RANDOM.nextInt(100, 50000));
+        }
+        playingCountRecordRepository.saveAllAndFlush(records);
+        log.info("Finished generating game leaderboard data.");
     }
 
     public record OrderUserGamePair(List<Order> orders, List<UserGame> userGames) {}

--- a/src/main/java/com/bravos/steak/store/repo/OrderRepository.java
+++ b/src/main/java/com/bravos/steak/store/repo/OrderRepository.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Repository;
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
     @EntityGraph(type = EntityGraph.EntityGraphType.FETCH,
-            attributePaths = {"orderDetails, userAccount"})
+            attributePaths = {"orderDetails", "userAccount"})
     @Query("SELECT o FROM Order o WHERE o.id = :id ")
     Order getFullOrderDetailsById(Long id);
 


### PR DESCRIPTION
This pull request updates the `Generator` class and related repository usage to support new leaderboard data generation functionality and fixes a minor bug in the `OrderRepository`. The main changes are the addition of dependencies for leaderboard statistics, a scheduled method for generating leaderboard data, and a syntax fix in an entity graph annotation.

**Leaderboard data generation improvements:**

* Added dependencies for `TrendingStatisticRepository` and `PlayingCountRecordRepository` to the `Generator` class, including constructor updates for dependency injection. [[1]](diffhunk://#diff-c9250bff1d2655c8510957d40e1e220e2e7162652fa0ea837d8e52d0e0d19b55L7-R7) [[2]](diffhunk://#diff-c9250bff1d2655c8510957d40e1e220e2e7162652fa0ea837d8e52d0e0d19b55R50-R63)
* Introduced a scheduled method `generateGameLeaderboard` to randomly update playing counts for all records and persist them, supporting automated leaderboard data generation.

**Repository annotation fix:**

* Fixed the `@EntityGraph` annotation in `OrderRepository` by changing the `attributePaths` from a comma-separated string to an array, ensuring proper entity graph fetching.