### PR TITLE
fix-filter

### DIFF
--- a/src/main/java/com/bravos/steak/store/model/request/FilterQuery.java
+++ b/src/main/java/com/bravos/steak/store/model/request/FilterQuery.java
@@ -17,9 +17,9 @@ public class FilterQuery {
 
     String keyword;
 
-    Long[] genreIds;
+    Long[] genreIds = new Long[0];
 
-    Long[] tagIds;
+    Long[] tagIds = new Long[0];
 
     Double minPrice;
 

--- a/src/main/java/com/bravos/steak/store/service/impl/GameServiceImpl.java
+++ b/src/main/java/com/bravos/steak/store/service/impl/GameServiceImpl.java
@@ -86,6 +86,7 @@ public class GameServiceImpl implements GameService {
             filterQuery.setMaxPrice(temp);
         }
         int hashCode = filterQuery.hashCode();
+        log.info("Filter query hash code: {}", hashCode);
 
         String key = "game:filter:" + hashCode;
         RedisCacheEntry<Object> cacheEntry = RedisCacheEntry.builder()

--- a/src/main/java/com/bravos/steak/store/specifications/GameSpecification.java
+++ b/src/main/java/com/bravos/steak/store/specifications/GameSpecification.java
@@ -63,15 +63,17 @@ public class GameSpecification {
                 predicates.add(root.join("tags").get("id").in((Object[]) filterQuery.getTagIds()));
             }
 
-            if (!Objects.equals(filterQuery.getMinPrice(), filterQuery.getMaxPrice())) {
-                if (filterQuery.getMinPrice() != null) {
+            if (filterQuery.getMinPrice() != null && filterQuery.getMaxPrice() != null) {
+                if (!Objects.equals(filterQuery.getMinPrice(), filterQuery.getMaxPrice())) {
                     predicates.add(cb.greaterThanOrEqualTo(root.get("price"), filterQuery.getMinPrice()));
-                }
-                if (filterQuery.getMaxPrice() != null) {
                     predicates.add(cb.lessThanOrEqualTo(root.get("price"), filterQuery.getMaxPrice()));
+                } else {
+                    predicates.add(cb.equal(root.get("price"), filterQuery.getMinPrice()));
                 }
             } else if (filterQuery.getMinPrice() != null) {
-                predicates.add(cb.equal(root.get("price"), filterQuery.getMinPrice()));
+                predicates.add(cb.greaterThanOrEqualTo(root.get("price"), filterQuery.getMinPrice()));
+            } else if (filterQuery.getMaxPrice() != null) {
+                predicates.add(cb.lessThanOrEqualTo(root.get("price"), filterQuery.getMaxPrice()));
             }
 
             if (filterQuery.getSortBy() != null && !filterQuery.getSortBy().isEmpty()) {


### PR DESCRIPTION
This pull request improves the filtering logic for games and enhances the robustness of the filter query model. The main changes include more precise handling of price filters, default initialization of filter arrays to avoid nulls, and improved logging for debugging filter queries.

**Filtering logic improvements:**

* Updated the price filter logic in `GameSpecification.withFilters` to handle cases where both `minPrice` and `maxPrice` are set and equal, ensuring exact price matches, and to properly support filtering by only minimum or maximum price.

**Model robustness:**

* Initialized `genreIds` and `tagIds` arrays in `FilterQuery` to empty arrays by default to prevent null pointer issues during filtering.

**Logging and debugging:**

* Added a log statement in `GameServiceImpl.getFilteredGames` to record the hash code of the filter query, aiding in cache key tracking and debugging.