### PR TITLE
fix-filter

### DIFF
--- a/src/main/java/com/bravos/steak/store/model/request/FilterQuery.java
+++ b/src/main/java/com/bravos/steak/store/model/request/FilterQuery.java
@@ -4,6 +4,7 @@ import lombok.*;
 import lombok.experimental.FieldDefaults;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 import static lombok.AccessLevel.PRIVATE;
 
@@ -33,16 +34,24 @@ public class FilterQuery {
 
     @Override
     public int hashCode() {
-        if (genreIds != null && genreIds.length > 0) {
-            Arrays.sort(genreIds);
+        Long[] sortedGenreIds = genreIds != null ? genreIds.clone() : null;
+        Long[] sortedTagIds = tagIds != null ? tagIds.clone() : null;
+        if (sortedGenreIds != null && sortedGenreIds.length > 0) {
+            Arrays.sort(sortedGenreIds);
         }
-        if (tagIds != null && tagIds.length > 0) {
-            Arrays.sort(tagIds);
+        if (sortedTagIds != null && sortedTagIds.length > 0) {
+            Arrays.sort(sortedTagIds);
         }
-        return Arrays.hashCode(new Object[]{
-                keyword, Arrays.hashCode(genreIds), Arrays.hashCode(tagIds),
-                minPrice, maxPrice, sortBy, page, pageSize
-        });
+        return Objects.hash(
+                keyword,
+                Arrays.hashCode(sortedGenreIds),
+                Arrays.hashCode(sortedTagIds),
+                minPrice,
+                maxPrice,
+                sortBy,
+                page,
+                pageSize
+        );
     }
 
     @Override

--- a/src/main/java/com/bravos/steak/store/specifications/GameSpecification.java
+++ b/src/main/java/com/bravos/steak/store/specifications/GameSpecification.java
@@ -11,7 +11,6 @@ import org.springframework.data.jpa.domain.Specification;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 
 public class GameSpecification {
@@ -64,12 +63,8 @@ public class GameSpecification {
             }
 
             if (filterQuery.getMinPrice() != null && filterQuery.getMaxPrice() != null) {
-                if (!Objects.equals(filterQuery.getMinPrice(), filterQuery.getMaxPrice())) {
-                    predicates.add(cb.greaterThanOrEqualTo(root.get("price"), filterQuery.getMinPrice()));
-                    predicates.add(cb.lessThanOrEqualTo(root.get("price"), filterQuery.getMaxPrice()));
-                } else {
-                    predicates.add(cb.equal(root.get("price"), filterQuery.getMinPrice()));
-                }
+                predicates.add(cb.greaterThanOrEqualTo(root.get("price"), filterQuery.getMinPrice()));
+                predicates.add(cb.lessThanOrEqualTo(root.get("price"), filterQuery.getMaxPrice()));
             } else if (filterQuery.getMinPrice() != null) {
                 predicates.add(cb.greaterThanOrEqualTo(root.get("price"), filterQuery.getMinPrice()));
             } else if (filterQuery.getMaxPrice() != null) {


### PR DESCRIPTION
This pull request refines the filtering logic and hash code calculation for game queries, focusing on improving correctness and maintainability. The main changes are in the `FilterQuery` and `GameSpecification` classes, addressing how price filters and array hashing are handled.

**Improvements to hash code calculation:**
- [`FilterQuery.java`](diffhunk://#diff-bd8c22b3b4cffae0f28868d2980cfe2a76387f590efc363330e7af13816799d8L36-R54): The `hashCode` method now clones and sorts the `genreIds` and `tagIds` arrays before hashing them, ensuring consistent hash codes regardless of input order. Additionally, it uses `Objects.hash` for better readability and maintainability.
- [`FilterQuery.java`](diffhunk://#diff-bd8c22b3b4cffae0f28868d2980cfe2a76387f590efc363330e7af13816799d8R7): Added import for `java.util.Objects` to support the updated hash code implementation.

**Filtering logic simplification:**
- [`GameSpecification.java`](diffhunk://#diff-386b945ba07f8e9c033beb501de8b10316d1ee39fae9522a5c600bdf4bdccf85L67-L72): Removed redundant equality check between `minPrice` and `maxPrice` in the filter logic. Now, both predicates for minimum and maximum price are always added when both values are present, simplifying the code and improving clarity.
- [`GameSpecification.java`](diffhunk://#diff-386b945ba07f8e9c033beb501de8b10316d1ee39fae9522a5c600bdf4bdccf85L14): Removed unused import of `java.util.Objects`, cleaning up the code.