### PR TITLE
Develop

### DIFF
--- a/src/main/java/com/bravos/steak/common/seed/Generator.java
+++ b/src/main/java/com/bravos/steak/common/seed/Generator.java
@@ -156,7 +156,7 @@ public class Generator {
         }
     }
 
-    @Scheduled(cron = "0 30 */1 * * *")
+//    @Scheduled(cron = "0 30 */1 * * *")
     public void generateRevenueData() {
         List<Game> games = gameRepository.findAll();
 

--- a/src/main/java/com/bravos/steak/store/service/impl/GameServiceImpl.java
+++ b/src/main/java/com/bravos/steak/store/service/impl/GameServiceImpl.java
@@ -77,7 +77,7 @@ public class GameServiceImpl implements GameService {
     @Override
     public CustomPage<GameListItem> getFilteredGames(FilterQuery filterQuery) {
         if(filterQuery == null) {
-            return getNewestGames(1,15);
+            return getNewestGames(1,12);
         }
         if(filterQuery.getMinPrice() != null && filterQuery.getMaxPrice() != null
                 && filterQuery.getMinPrice() > filterQuery.getMaxPrice()) {
@@ -92,7 +92,7 @@ public class GameServiceImpl implements GameService {
         RedisCacheEntry<Object> cacheEntry = RedisCacheEntry.builder()
                 .key(key)
                 .fallBackFunction(() -> getFilteredGamesFromDb(filterQuery))
-                .keyTimeout(5)
+                .keyTimeout(1)
                 .keyTimeUnit(TimeUnit.MINUTES)
                 .lockTimeout(2000)
                 .lockTimeUnit(TimeUnit.MILLISECONDS)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,5 +25,5 @@ spring:
   jpa:
     hibernate:
       ddl-auto: none
-    show-sql: ${SHOW_SQL}
+    show-sql: true
     open-in-view: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,5 +25,5 @@ spring:
   jpa:
     hibernate:
       ddl-auto: none
-    show-sql: true
+    show-sql: ${SHOW_SQL}
     open-in-view: false


### PR DESCRIPTION
This pull request introduces minor updates to the game filtering and caching logic, and comments out a scheduled revenue data generation method. The changes mainly focus on refining default values and caching behavior.

Game filtering and pagination:

* Reduced the default page size for the `getNewestGames` method from 15 to 12 when no filter is provided, affecting the number of games returned in the absence of filters.

Caching configuration:

* Decreased the Redis cache key timeout from 5 minutes to 1 minute in the `getFilteredGames` method, resulting in more frequent cache refreshes for filtered game lists.

Scheduled job management:

* Commented out the `@Scheduled` annotation for the `generateRevenueData` method in `Generator.java`, disabling its automatic execution.