### PR TITLE
fix-filter

### DIFF
--- a/src/main/java/com/bravos/steak/store/specifications/GameSpecification.java
+++ b/src/main/java/com/bravos/steak/store/specifications/GameSpecification.java
@@ -63,8 +63,12 @@ public class GameSpecification {
             }
 
             if (filterQuery.getMinPrice() != null && filterQuery.getMaxPrice() != null) {
-                predicates.add(cb.greaterThanOrEqualTo(root.get("price"), filterQuery.getMinPrice()));
-                predicates.add(cb.lessThanOrEqualTo(root.get("price"), filterQuery.getMaxPrice()));
+                if (filterQuery.getMinPrice().equals(0.0) && filterQuery.getMaxPrice().equals(0.0)) {
+                    predicates.add(cb.equal(root.get("price"), 0.0));
+                } else {
+                    predicates.add(cb.greaterThanOrEqualTo(root.get("price"), filterQuery.getMinPrice()));
+                    predicates.add(cb.lessThanOrEqualTo(root.get("price"), filterQuery.getMaxPrice()));
+                }
             } else if (filterQuery.getMinPrice() != null) {
                 predicates.add(cb.greaterThanOrEqualTo(root.get("price"), filterQuery.getMinPrice()));
             } else if (filterQuery.getMaxPrice() != null) {


### PR DESCRIPTION
This pull request introduces a small but important update to the price filtering logic in the `GameSpecification.java` file. The change ensures that when both the minimum and maximum price filters are set to zero, only games with a price exactly equal to zero are returned, rather than games with prices in a range from zero upwards.

* Price filtering logic: Updated the `withFilters` method to add a special case for when both `minPrice` and `maxPrice` are zero, so only games with a price of exactly zero are returned.