### PR TITLE
fix-has-authority-annotation

### DIFF
--- a/src/main/java/com/bravos/steak/common/annotation/AuthorityChecker.java
+++ b/src/main/java/com/bravos/steak/common/annotation/AuthorityChecker.java
@@ -1,0 +1,52 @@
+package com.bravos.steak.common.annotation;
+
+import com.bravos.steak.common.security.JwtAuthentication;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component("authorityChecker")
+public class AuthorityChecker {
+
+    public boolean hasAnyAuthority(String... authorities) {
+        if (authorities == null || authorities.length == 0) {
+            return false;
+        }
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated()) {
+            return false;
+        }
+
+        if(auth instanceof JwtAuthentication authentication) {
+            List<GrantedAuthority> authoritiesList = new ArrayList<>(authentication.getAuthorities());
+            if(authoritiesList.isEmpty()) return false;
+            Set<String> neededAuthorities = Set.of(authorities);
+            Set<String> userAuthorities = authoritiesList.stream().map(GrantedAuthority::getAuthority).collect(Collectors.toSet());
+
+            if(userAuthorities.contains("PUBLISHER_MASTER") && authorities[0].contains("PUBLISHER_")) {
+                return true;
+            }
+            if(userAuthorities.contains("ADMIN_MASTER") && (authorities[0].contains("ADMIN_"))) {
+                return true;
+            }
+            for (String authority : userAuthorities) {
+                if (neededAuthorities.contains(authority)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    public boolean checkAuthority(String authority) {
+        return hasAnyAuthority(authority);
+    }
+
+}

--- a/src/main/java/com/bravos/steak/common/annotation/HasAuthority.java
+++ b/src/main/java/com/bravos/steak/common/annotation/HasAuthority.java
@@ -1,17 +1,12 @@
 package com.bravos.steak.common.annotation;
 
-import org.springframework.security.access.prepost.PreAuthorize;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target({ElementType.METHOD,ElementType.TYPE})
+@Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
-@PreAuthorize("hasAnyAuthority(#value)")
 public @interface HasAuthority {
-
     String[] value();
-
 }

--- a/src/main/java/com/bravos/steak/common/annotation/HasAuthorityAspect.java
+++ b/src/main/java/com/bravos/steak/common/annotation/HasAuthorityAspect.java
@@ -1,0 +1,27 @@
+package com.bravos.steak.common.annotation;
+
+import com.bravos.steak.exceptions.ForbiddenException;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class HasAuthorityAspect {
+
+    private final AuthorityChecker authorityChecker;
+
+    public HasAuthorityAspect(AuthorityChecker authorityChecker) {
+        this.authorityChecker = authorityChecker;
+    }
+
+    @Around("@annotation(hasAuthority)")
+    public Object checkAuthority(ProceedingJoinPoint joinPoint, HasAuthority hasAuthority) throws Throwable {
+        if (!authorityChecker.hasAnyAuthority(hasAuthority.value())) {
+            throw new ForbiddenException("Access denied");
+        }
+        return joinPoint.proceed();
+    }
+
+}

--- a/src/main/java/com/bravos/steak/store/model/response/GameStoreDetail.java
+++ b/src/main/java/com/bravos/steak/store/model/response/GameStoreDetail.java
@@ -30,6 +30,8 @@ public class GameStoreDetail {
 
     private Boolean isOwned;
 
+    private Long releaseDate;
+
     private String latestVersionName;
 
 }

--- a/src/main/java/com/bravos/steak/store/service/impl/GameServiceImpl.java
+++ b/src/main/java/com/bravos/steak/store/service/impl/GameServiceImpl.java
@@ -459,6 +459,7 @@ public class GameServiceImpl implements GameService {
                 .publisherName(game.getPublisher().getName())
                 .tags(game.getTags().stream().toList())
                 .genres(game.getGenres().stream().toList())
+                .releaseDate(game.getReleaseDate())
                 .latestVersionName(latestVersion != null ? latestVersion.getName() : "N/A")
                 .build();
     }


### PR DESCRIPTION
This pull request introduces a new custom authority checking mechanism to replace the previous use of Spring Security's `@PreAuthorize` annotation, and updates the game store detail response to include a release date. The most important changes are grouped below by theme.

### Authorization system refactor

* Added a new `AuthorityChecker` component with custom logic for checking user authorities, including support for master roles and authority hierarchies. (`AuthorityChecker.java`)
* Removed the dependency on Spring Security's `@PreAuthorize` from the `HasAuthority` annotation, making it a pure marker annotation. (`HasAuthority.java`)
* Introduced a new `HasAuthorityAspect` aspect to enforce authority checks at runtime using the custom `AuthorityChecker`, throwing a `ForbiddenException` when access is denied. (`HasAuthorityAspect.java`)

### Game store detail response enhancement

* Added a new `releaseDate` field to the `GameStoreDetail` response model to provide clients with game release information. (`GameStoreDetail.java`)
* Updated the `getGameStoreDetailFromDb` method to populate the new `releaseDate` field from the database entity. (`GameServiceImpl.java`)