### PR TITLE
fix-hashcode-query

### DIFF
--- a/src/main/java/com/bravos/steak/store/model/request/FilterQuery.java
+++ b/src/main/java/com/bravos/steak/store/model/request/FilterQuery.java
@@ -42,12 +42,16 @@ public class FilterQuery {
         if (sortedTagIds != null && sortedTagIds.length > 0) {
             Arrays.sort(sortedTagIds);
         }
+
+        int minPriceHash = (minPrice != null) ? minPrice.hashCode() : -1;
+        int maxPriceHash = (maxPrice != null) ? maxPrice.hashCode() : -1;
+
         return Objects.hash(
                 keyword,
                 Arrays.hashCode(sortedGenreIds),
                 Arrays.hashCode(sortedTagIds),
-                minPrice,
-                maxPrice,
+                minPriceHash,
+                maxPriceHash,
                 sortBy,
                 page,
                 pageSize


### PR DESCRIPTION
This pull request updates the way the `hashCode()` method is implemented in the `FilterQuery` model to improve hash calculation for price fields. Instead of directly using `minPrice` and `maxPrice`, their hash codes are now computed and used, which helps avoid potential issues with null values and ensures consistency.

Hash code calculation improvements:

* In `FilterQuery.java`, the `hashCode()` method now uses the hash codes of `minPrice` and `maxPrice`, defaulting to -1 if either is null, instead of using the objects themselves.