### PR TITLE
Develop

### DIFF
--- a/src/main/java/com/bravos/steak/common/model/CustomPageInfo.java
+++ b/src/main/java/com/bravos/steak/common/model/CustomPageInfo.java
@@ -19,7 +19,7 @@ public class CustomPageInfo implements Serializable {
 
     int number;
 
-    int totalElements;
+    long totalElements;
 
     int totalPages;
 

--- a/src/main/java/com/bravos/steak/common/service/email/impl/EmailServiceImpl.java
+++ b/src/main/java/com/bravos/steak/common/service/email/impl/EmailServiceImpl.java
@@ -41,14 +41,14 @@ public class EmailServiceImpl implements EmailService {
         if (!emailPayloads.isEmpty()) {
             if (emailPayloads.size() == 1) {
                 EmailPayload emailPayload = emailPayloads.removeFirst();
-                if (emailPayload != null && !emailPayload.getTemplateID().isBlank()) {
+                if (emailPayload != null) {
                     this.sendSingleEmail(emailPayload).subscribe();
                 }
             } else {
                 List<EmailPayload> payloadsToSend = new ArrayList<>(50);
                 while (!emailPayloads.isEmpty() && payloadsToSend.size() < 50) {
                     EmailPayload emailPayload = emailPayloads.removeFirst();
-                    if (emailPayload != null && !emailPayload.getTemplateID().isBlank()) {
+                    if (emailPayload != null) {
                         payloadsToSend.add(emailPayload);
                     }
                 }

--- a/src/main/java/com/bravos/steak/dev/controller/PublisherStatisticController.java
+++ b/src/main/java/com/bravos/steak/dev/controller/PublisherStatisticController.java
@@ -1,7 +1,11 @@
 package com.bravos.steak.dev.controller;
 
 import com.bravos.steak.common.annotation.PublisherController;
+import com.bravos.steak.dev.service.GameStatisticService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -9,6 +13,18 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/dev/statistics")
 public class PublisherStatisticController {
 
+    private final GameStatisticService gameStatisticService;
 
+    public PublisherStatisticController(GameStatisticService gameStatisticService) {
+        this.gameStatisticService = gameStatisticService;
+    }
+
+    @GetMapping("/games/revenue")
+    public ResponseEntity<?> getGameStatisticsRevenue(@RequestParam(required = false) Integer month,
+                                                      @RequestParam(required = false) Integer year,
+                                                      @RequestParam(defaultValue = "1") int page,
+                                                      @RequestParam(defaultValue = "10") int pageSize) {
+        return ResponseEntity.ok(gameStatisticService.getGameStatisticsRevenue(month, year, page - 1, pageSize));
+    }
 
 }

--- a/src/main/java/com/bravos/steak/dev/controller/PublisherStatisticController.java
+++ b/src/main/java/com/bravos/steak/dev/controller/PublisherStatisticController.java
@@ -1,6 +1,8 @@
 package com.bravos.steak.dev.controller;
 
+import com.bravos.steak.common.annotation.HasAuthority;
 import com.bravos.steak.common.annotation.PublisherController;
+import com.bravos.steak.dev.model.PublisherAuthority;
 import com.bravos.steak.dev.service.GameStatisticService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,6 +22,7 @@ public class PublisherStatisticController {
     }
 
     @GetMapping("/games/revenue")
+    @HasAuthority({PublisherAuthority.READ_REVENUE_STATISTIC})
     public ResponseEntity<?> getGameStatisticsRevenue(@RequestParam(required = false) Integer month,
                                                       @RequestParam(required = false) Integer year,
                                                       @RequestParam(defaultValue = "1") int page,

--- a/src/main/java/com/bravos/steak/dev/model/response/GameStatisticItem.java
+++ b/src/main/java/com/bravos/steak/dev/model/response/GameStatisticItem.java
@@ -1,0 +1,28 @@
+package com.bravos.steak.dev.model.response;
+
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+import java.math.BigDecimal;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@FieldDefaults(level = PRIVATE)
+public class GameStatisticItem {
+
+    Long gameId;
+
+    String title;
+
+    String thumbnail;
+
+    Long totalSold;
+
+    BigDecimal totalRevenue;
+
+}

--- a/src/main/java/com/bravos/steak/dev/service/GameStatisticService.java
+++ b/src/main/java/com/bravos/steak/dev/service/GameStatisticService.java
@@ -1,0 +1,10 @@
+package com.bravos.steak.dev.service;
+
+import com.bravos.steak.common.model.CustomPage;
+import com.bravos.steak.dev.model.response.GameStatisticItem;
+
+public interface GameStatisticService {
+
+    CustomPage<GameStatisticItem> getGameStatisticsRevenue(Integer month, Integer year, int page, int pageSize);
+
+}

--- a/src/main/java/com/bravos/steak/dev/service/impl/GameStatisticServiceImpl.java
+++ b/src/main/java/com/bravos/steak/dev/service/impl/GameStatisticServiceImpl.java
@@ -19,10 +19,10 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 @Service
 public class GameStatisticServiceImpl implements GameStatisticService {
@@ -89,9 +89,11 @@ public class GameStatisticServiceImpl implements GameStatisticService {
 
         List<Long> gameIds = result.stream().map(GameStatisticItem::getGameId).toList();
         List<GameThumbnail> thumbnails = gameDetailsRepository.findThumbnailsByIdIn(gameIds);
-        Map<Long, GameStatisticItem> resultMap = result.stream().collect(
-                Collectors.toMap(GameStatisticItem::getGameId, item -> item)
-        );
+
+        Map<Long, GameStatisticItem> resultMap = new LinkedHashMap<>(gameIds.size());
+        for(GameStatisticItem item : result) {
+            resultMap.put(item.getGameId(), item);
+        }
 
         for(GameThumbnail thumbnail : thumbnails) {
             GameStatisticItem item = resultMap.get(thumbnail.getId());

--- a/src/main/java/com/bravos/steak/dev/service/impl/GameStatisticServiceImpl.java
+++ b/src/main/java/com/bravos/steak/dev/service/impl/GameStatisticServiceImpl.java
@@ -1,0 +1,116 @@
+package com.bravos.steak.dev.service.impl;
+
+import com.bravos.steak.common.model.CustomPage;
+import com.bravos.steak.common.model.CustomPageInfo;
+import com.bravos.steak.common.model.RedisCacheEntry;
+import com.bravos.steak.common.security.JwtTokenClaims;
+import com.bravos.steak.common.service.auth.SessionService;
+import com.bravos.steak.common.service.helper.DateTimeHelper;
+import com.bravos.steak.common.service.redis.RedisService;
+import com.bravos.steak.dev.model.GameThumbnail;
+import com.bravos.steak.dev.model.response.GameStatisticItem;
+import com.bravos.steak.dev.service.GameStatisticService;
+import com.bravos.steak.store.repo.GameDetailsRepository;
+import com.bravos.steak.store.repo.OrderDetailsRepository;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+@Service
+public class GameStatisticServiceImpl implements GameStatisticService {
+
+    private final OrderDetailsRepository orderDetailsRepository;
+    private final GameDetailsRepository gameDetailsRepository;
+    private final SessionService sessionService;
+    private final RedisService redisService;
+    private final ObjectMapper objectMapper;
+
+    public GameStatisticServiceImpl(OrderDetailsRepository orderDetailsRepository,
+                                    GameDetailsRepository gameDetailsRepository,
+                                    SessionService sessionService,
+                                    RedisService redisService,
+                                    ObjectMapper objectMapper) {
+        this.orderDetailsRepository = orderDetailsRepository;
+        this.gameDetailsRepository = gameDetailsRepository;
+        this.sessionService = sessionService;
+        this.redisService = redisService;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public CustomPage<GameStatisticItem> getGameStatisticsRevenue(Integer month, Integer year, int page, int pageSize) {
+        String key = "game_statistics_revenue_" + month + "_" + year + "_" + page + "_" + pageSize + "_" + getCurrentPublisherId();
+        RedisCacheEntry<Object> cacheEntry = RedisCacheEntry.builder()
+                .key(key)
+                .fallBackFunction(() -> getGameStatisticsRevenueFromDb(month, year, page, pageSize))
+                .keyTimeout(5)
+                .keyTimeUnit(TimeUnit.MINUTES)
+                .retryWait(500)
+                .retryTime(3)
+                .lockTimeout(1500)
+                .lockTimeUnit(TimeUnit.MILLISECONDS)
+                .build();
+        Object value = redisService.getWithLock(cacheEntry, Object.class);
+        return objectMapper.convertValue(value, new TypeReference<>() {});
+    }
+
+    public CustomPage<GameStatisticItem> getGameStatisticsRevenueFromDb(Integer month, Integer year, int page, int pageSize) {
+        Page<GameStatisticItem> result;
+        Long publisherId = getCurrentPublisherId();
+        if(month == null && year == null) {
+            result = orderDetailsRepository.getGameStatisticsRevenue(publisherId, PageRequest.of(page, pageSize));
+        } else {
+            LocalDateTime from;
+            LocalDateTime to;
+            if(month == null) {
+                from = LocalDateTime.of(year, 1, 1, 0, 0);
+                to = from.plusYears(1);
+            } else if(year == null) {
+                from = LocalDateTime.of(LocalDateTime.now().getYear(), month, 1, 0, 0);
+                to = from.plusMonths(1);
+            } else {
+                from = LocalDateTime.of(year, month, 1, 0, 0);
+                to = from.plusMonths(1);
+            }
+            Long fromMillis = DateTimeHelper.from(from);
+            Long toMillis = DateTimeHelper.from(to);
+            result = orderDetailsRepository.getGameStatisticsRevenue(publisherId, fromMillis, toMillis, PageRequest.of(page, pageSize));
+        }
+
+        if(result.isEmpty()) return new CustomPage<>(result);
+
+        List<Long> gameIds = result.stream().map(GameStatisticItem::getGameId).toList();
+        List<GameThumbnail> thumbnails = gameDetailsRepository.findThumbnailsByIdIn(gameIds);
+        Map<Long, GameStatisticItem> resultMap = result.stream().collect(
+                Collectors.toMap(GameStatisticItem::getGameId, item -> item)
+        );
+
+        for(GameThumbnail thumbnail : thumbnails) {
+            GameStatisticItem item = resultMap.get(thumbnail.getId());
+            item.setThumbnail(thumbnail.getThumbnail());
+        }
+
+        List<GameStatisticItem> content = resultMap.values().stream().toList();
+
+        return new CustomPage<>(content, CustomPageInfo.builder()
+                .number(result.getNumber())
+                .size(result.getSize())
+                .totalElements(result.getTotalElements())
+                .totalPages(result.getTotalPages())
+                .build());
+    }
+
+    private Long getCurrentPublisherId() {
+        JwtTokenClaims claims = (JwtTokenClaims) sessionService.getAuthentication().getDetails();
+        return Long.parseLong(claims.getOtherClaims().get("publisherId").toString());
+    }
+
+}

--- a/src/main/java/com/bravos/steak/store/repo/OrderDetailsRepository.java
+++ b/src/main/java/com/bravos/steak/store/repo/OrderDetailsRepository.java
@@ -1,12 +1,32 @@
 package com.bravos.steak.store.repo;
 
+import com.bravos.steak.dev.model.response.GameStatisticItem;
 import com.bravos.steak.store.entity.OrderDetails;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface OrderDetailsRepository extends JpaRepository<OrderDetails, Long> {
-  List<OrderDetails> findByOrder_Id(Long orderId);
+
+    List<OrderDetails> findByOrder_Id(Long orderId);
 
     List<OrderDetails> findByOrderId(Long orderId);
+
+    @Query("SELECT new com.bravos.steak.dev.model.response.GameStatisticItem(od.game.id, od.game.name, '', COUNT(od.id), SUM(od.price)) " +
+            "FROM OrderDetails od " +
+            "WHERE od.game.publisher.id = :publisherId " +
+            "GROUP BY od.game.id, od.game.name " +
+            "ORDER BY SUM(od.price) DESC")
+    Page<GameStatisticItem> getGameStatisticsRevenue(Long publisherId, Pageable pageable);
+
+    @Query("SELECT new com.bravos.steak.dev.model.response.GameStatisticItem(od.game.id, od.game.name, '', COUNT(od.id), SUM(od.price)) " +
+            "FROM OrderDetails od " +
+            "WHERE od.order.createdAt BETWEEN :from AND :to AND od.game.publisher.id = :publisherId " +
+            "GROUP BY od.game.id, od.game.name " +
+            "ORDER BY SUM(od.price) DESC")
+    Page<GameStatisticItem> getGameStatisticsRevenue(Long publisherId, Long from, Long to, Pageable pageable);
+
 }

--- a/src/main/java/com/bravos/steak/store/repo/OrderRepository.java
+++ b/src/main/java/com/bravos/steak/store/repo/OrderRepository.java
@@ -14,4 +14,6 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     @Query("SELECT o FROM Order o WHERE o.id = :id ")
     Order getFullOrderDetailsById(Long id);
 
+
+
 }


### PR DESCRIPTION
This pull request introduces a new feature for retrieving paginated game revenue statistics for publishers, including backend service, controller, model, and repository updates. It also makes a minor fix to the paging model and refines email batching logic. The main changes are grouped below:

**Game Revenue Statistics Feature:**

* Added `GameStatisticService` interface and `GameStatisticServiceImpl` implementation, providing a method to fetch paginated game revenue statistics with caching and publisher-based filtering. [[1]](diffhunk://#diff-046900a4048f4e3ead072dbc3eea053d51384488f8275d5a085158a19ad81b25R1-R10) [[2]](diffhunk://#diff-baf4915018374f92cadce5d8759f9cfb7b8531b12f6979d7009ecbdfaf701e3aR1-R118)
* Introduced the `GameStatisticItem` response model to encapsulate game ID, title, thumbnail, total sold, and total revenue.
* Updated `OrderDetailsRepository` with new queries to aggregate revenue and sales count per game, supporting both all-time and date-filtered statistics.
* Created the `PublisherStatisticController` endpoint `/api/v1/dev/statistics/games/revenue`, secured by publisher authority, to expose the statistics API.

**General Improvements & Fixes:**

* Changed the type of `totalElements` in `CustomPageInfo` from `int` to `long` to support larger result sets.
* Relaxed email batching logic in `EmailServiceImpl` to allow processing emails even if the template ID is blank, improving flexibility.

These changes collectively add a robust, secure, and performant way for publishers to view their game revenue statistics, while also improving paging and email handling.