### PR TITLE
remove-restrict-ip-address

### DIFF
--- a/src/main/java/com/bravos/steak/dev/service/impl/GameManagerServiceImpl.java
+++ b/src/main/java/com/bravos/steak/dev/service/impl/GameManagerServiceImpl.java
@@ -154,8 +154,6 @@ public class GameManagerServiceImpl implements GameManagerService {
 
             }
             return gameService.invalidateAndGetGameStoreDetails(gameId);
-        } catch (RuntimeException e) {
-            throw new RuntimeException(e);
         } finally {
             invalidateFullGameDetailsCache(request.getGameId());
         }

--- a/src/main/java/com/bravos/steak/store/service/impl/DownloadGameServiceImpl.java
+++ b/src/main/java/com/bravos/steak/store/service/impl/DownloadGameServiceImpl.java
@@ -35,7 +35,7 @@ public class DownloadGameServiceImpl implements DownloadGameService {
                 .keyPairId(cdnKeyPair.getKeyPairId())
                 .privateKey(cdnKeyPair.getPrivateKey())
                 .expirationDate(expirationTime)
-                .ipRange(ipAddress + "/32")
+//                .ipRange(ipAddress + "/32")
                 .build();
         SignedUrl signedUrl = cloudFrontUtilities.getSignedUrlWithCustomPolicy(customSignerRequest);
         log.info("Request to download game from IP: {}", ipAddress);


### PR DESCRIPTION
This pull request makes minor changes to exception handling and IP restriction logic in the game management and download services. The most notable updates are the removal of redundant exception wrapping and the disabling of IP-based download URL restrictions.

Exception handling improvement:

* Removed unnecessary wrapping of `RuntimeException` in `updateGameDetails` in `GameManagerServiceImpl.java`, simplifying error propagation.

Download URL logic change:

* Disabled the IP address restriction in the signed URL generation by commenting out the `.ipRange` configuration in `DownloadGameServiceImpl.java`.